### PR TITLE
Fixes for drivers with STAGE_UNSTAGE_VOLUME capability

### DIFF
--- a/cmd/csi-sanity/sanity_test.go
+++ b/cmd/csi-sanity/sanity_test.go
@@ -29,16 +29,16 @@ const (
 )
 
 var (
-	VERSION    = "(dev)"
-	endpoint   string
-	mountPoint string
-	version    bool
+	VERSION  = "(dev)"
+	endpoint string
+	mountDir string
+	version  bool
 )
 
 func init() {
 	flag.StringVar(&endpoint, prefix+"endpoint", "", "CSI endpoint")
 	flag.BoolVar(&version, prefix+"version", false, "Version of this program")
-	flag.StringVar(&mountPoint, prefix+"mountpoint", os.TempDir()+"/csi", "Mount point for NodePublish")
+	flag.StringVar(&mountDir, prefix+"mountdir", os.TempDir()+"/csi", "Mount point for NodePublish")
 	flag.Parse()
 }
 
@@ -50,5 +50,5 @@ func TestSanity(t *testing.T) {
 	if len(endpoint) == 0 {
 		t.Fatalf("--%sendpoint must be provided with an CSI endpoint", prefix)
 	}
-	sanity.Test(t, endpoint, mountPoint)
+	sanity.Test(t, endpoint, mountDir)
 }

--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -34,7 +34,7 @@ func verifyVolumeInfo(v *csi.Volume) {
 	Expect(v.GetId()).NotTo(BeEmpty())
 }
 
-func isCapabilitySupported(
+func isControllerCapabilitySupported(
 	c csi.ControllerClient,
 	capType csi.ControllerServiceCapability_RPC_Type,
 ) bool {
@@ -97,7 +97,7 @@ var _ = Describe("GetCapacity [Controller Server]", func() {
 	BeforeEach(func() {
 		c = csi.NewControllerClient(conn)
 
-		if !isCapabilitySupported(c, csi.ControllerServiceCapability_RPC_GET_CAPACITY) {
+		if !isControllerCapabilitySupported(c, csi.ControllerServiceCapability_RPC_GET_CAPACITY) {
 			Skip("GetCapacity not supported")
 		}
 	})
@@ -121,7 +121,7 @@ var _ = Describe("ListVolumes [Controller Server]", func() {
 	BeforeEach(func() {
 		c = csi.NewControllerClient(conn)
 
-		if !isCapabilitySupported(c, csi.ControllerServiceCapability_RPC_LIST_VOLUMES) {
+		if !isControllerCapabilitySupported(c, csi.ControllerServiceCapability_RPC_LIST_VOLUMES) {
 			Skip("ListVolumes not supported")
 		}
 	})
@@ -152,7 +152,7 @@ var _ = Describe("CreateVolume [Controller Server]", func() {
 	BeforeEach(func() {
 		c = csi.NewControllerClient(conn)
 
-		if !isCapabilitySupported(c, csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME) {
+		if !isControllerCapabilitySupported(c, csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME) {
 			Skip("CreateVolume not supported")
 		}
 	})
@@ -419,7 +419,7 @@ var _ = Describe("DeleteVolume [Controller Server]", func() {
 	BeforeEach(func() {
 		c = csi.NewControllerClient(conn)
 
-		if !isCapabilitySupported(c, csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME) {
+		if !isControllerCapabilitySupported(c, csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME) {
 			Skip("DeleteVolume not supported")
 		}
 	})
@@ -585,7 +585,7 @@ var _ = Describe("ControllerPublishVolume [Controller Server]", func() {
 		c = csi.NewControllerClient(conn)
 		n = csi.NewNodeClient(conn)
 
-		if !isCapabilitySupported(c, csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME) {
+		if !isControllerCapabilitySupported(c, csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME) {
 			Skip("ControllerPublishVolume not supported")
 		}
 	})
@@ -715,7 +715,7 @@ var _ = Describe("ControllerUnpublishVolume [Controller Server]", func() {
 		c = csi.NewControllerClient(conn)
 		n = csi.NewNodeClient(conn)
 
-		if !isCapabilitySupported(c, csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME) {
+		if !isControllerCapabilitySupported(c, csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME) {
 			Skip("ControllerUnpublishVolume not supported")
 		}
 	})


### PR DESCRIPTION
Existing tests do not support drivers with STAGE_UNSTAGE_VOLUME capability.

Additionally there was a duplicate test in `NodeUnpublishVolume` with one in `NodePublishVolume`.  I deleted the duplicate version. More details for long-term fix in #52 

/assign @lpabon @sbezverk 