### PR TITLE
Testing with 'RequiredBytes' should use it as a minimum value according to spec

### DIFF
--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -251,7 +251,7 @@ var _ = Describe("CreateVolume [Controller Server]", func() {
 			Expect(vol).NotTo(BeNil())
 			Expect(vol.GetVolume()).NotTo(BeNil())
 			Expect(vol.GetVolume().GetId()).NotTo(BeEmpty())
-			Expect(vol.GetVolume().GetCapacityBytes()).To(Equal(size))
+			Expect(vol.GetVolume().GetCapacityBytes()).To(BeNumerically(">=", size))
 		}
 		By("cleaning up deleting the volume")
 		_, err = c.DeleteVolume(
@@ -288,7 +288,7 @@ var _ = Describe("CreateVolume [Controller Server]", func() {
 		Expect(vol1).NotTo(BeNil())
 		Expect(vol1.GetVolume()).NotTo(BeNil())
 		Expect(vol1.GetVolume().GetId()).NotTo(BeEmpty())
-		Expect(vol1.GetVolume().GetCapacityBytes()).To(Equal(size))
+		Expect(vol1.GetVolume().GetCapacityBytes()).To(BeNumerically(">=", size))
 		vol2, err := c.CreateVolume(
 			context.Background(),
 			&csi.CreateVolumeRequest{
@@ -311,7 +311,7 @@ var _ = Describe("CreateVolume [Controller Server]", func() {
 		Expect(vol2).NotTo(BeNil())
 		Expect(vol2.GetVolume()).NotTo(BeNil())
 		Expect(vol2.GetVolume().GetId()).NotTo(BeEmpty())
-		Expect(vol2.GetVolume().GetCapacityBytes()).To(Equal(size))
+		Expect(vol2.GetVolume().GetCapacityBytes()).To(BeNumerically(">=", size))
 		Expect(vol1.GetVolume().GetId()).To(Equal(vol2.GetVolume().GetId()))
 
 		By("cleaning up deleting the volume")


### PR DESCRIPTION
The Spec on required bytes:
  // Volume must be at least this big. This field is OPTIONAL.
  // A value of 0 is equal to an unspecified field value.
  // The value of this field MUST NOT be negative. 
  int64 required_bytes = 1;

Therefore tests should accept any CreateVolume return size greater than or equal to the required bytes size.