### PR TITLE
Add CSI crentials tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -188,6 +188,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d953393850efa90c442b607a076291db1b050e1c9523ce86fefc85fda0443b8f"
+  inputs-digest = "562cbe769634e3939bddf9c49d3f189ced5cdcfd0f7e98f2bd2fa5aec32d3ec6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -49,6 +49,10 @@
   name = "google.golang.org/grpc"
   version = "1.9.2"
 
+[[constraint]]
+  name = "gopkg.in/yaml.v2"
+  version = "v2.1.1"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/cmd/csi-sanity/README.md
+++ b/cmd/csi-sanity/README.md
@@ -19,6 +19,30 @@ For verbose type:
 $ csi-sanity --ginkgo.v --csi.endpoint=<your csi driver endpoint>
 ```
 
+For csi-credentials, create a secrets file with all the secrets in it:
+```yaml
+CreateVolumeSecret:
+  secretKey: secretval1
+DeleteVolumeSecret:
+  secretKey: secretval2
+ControllerPublishVolumeSecret:
+  secretKey: secretval3
+ControllerUnpublishVolumeSecret:
+  secretKey: secretval4
+NodeStageVolumeSecret:
+  secretKey: secretval5
+NodePublishVolumeSecret:
+  secretKey: secretval6
+```
+
+Pass the file path to csi-sanity as:
+```
+$ csi-sanity --csi.endpoint=<your csi driver endpoint> --csi.secrets=<path to secrets file>
+```
+
+Replace the keys and values of the credentials appropriately. Since the whole
+secret is passed in the request, multiple key-val pairs can be used.
+
 ### Help
 The full Ginkgo and golang unit test parameters are available. Type
 

--- a/cmd/csi-sanity/sanity_test.go
+++ b/cmd/csi-sanity/sanity_test.go
@@ -39,6 +39,7 @@ func init() {
 	flag.BoolVar(&version, prefix+"version", false, "Version of this program")
 	flag.StringVar(&config.TargetPath, prefix+"mountdir", os.TempDir()+"/csi", "Mount point for NodePublish")
 	flag.StringVar(&config.StagingPath, prefix+"stagingdir", os.TempDir()+"/csi", "Mount point for NodeStage if staging is supported")
+	flag.StringVar(&config.SecretsFile, prefix+"secrets", "", "CSI secrets file")
 	flag.Parse()
 }
 

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -22,6 +22,19 @@ runTest()
 	fi
 }
 
+runTestWithCreds()
+{
+	CSI_ENDPOINT=$1 CSI_ENABLE_CREDS=true mock &
+	local pid=$!
+
+	csi-sanity $TESTARGS --csi.endpoint=$2 --csi.secrets=mock/mocksecret.yaml; ret=$?
+	kill -9 $pid
+
+	if [ $ret -ne 0 ] ; then
+		exit $ret
+	fi
+}
+
 go install ./mock || exit 1
 
 cd cmd/csi-sanity
@@ -29,6 +42,9 @@ cd cmd/csi-sanity
 cd ../..
 
 runTest "${UDS}" "${UDS}"
+rm -f $UDS
+
+runTestWithCreds "${UDS}" "${UDS}"
 rm -f $UDS
 
 exit 0

--- a/mock/main.go
+++ b/mock/main.go
@@ -47,6 +47,12 @@ func main() {
 	}
 	d := driver.NewCSIDriver(servers)
 
+	// If creds is enabled, set the default creds.
+	setCreds := os.Getenv("CSI_ENABLE_CREDS")
+	if len(setCreds) > 0 && setCreds == "true" {
+		d.SetDefaultCreds()
+	}
+
 	// Listen
 	os.Remove(endpoint)
 	l, err := net.Listen("unix", endpoint)

--- a/mock/mocksecret.yaml
+++ b/mock/mocksecret.yaml
@@ -1,0 +1,12 @@
+CreateVolumeSecret:
+  secretKey: secretval1
+DeleteVolumeSecret:
+  secretKey: secretval2
+ControllerPublishVolumeSecret:
+  secretKey: secretval3
+ControllerUnpublishVolumeSecret:
+  secretKey: secretval4
+NodeStageVolumeSecret:
+  secretKey: secretval5
+NodePublishVolumeSecret:
+  secretKey: secretval6

--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -124,9 +124,13 @@ var _ = Describe("NodePublishVolume [Node Server]", func() {
 
 	It("should fail when no volume id is provided", func() {
 
-		_, err := c.NodePublishVolume(
-			context.Background(),
-			&csi.NodePublishVolumeRequest{})
+		req := &csi.NodePublishVolumeRequest{}
+
+		if secrets != nil {
+			req.NodePublishSecrets = secrets.NodePublishVolumeSecret
+		}
+
+		_, err := c.NodePublishVolume(context.Background(), req)
 		Expect(err).To(HaveOccurred())
 
 		serverError, ok := status.FromError(err)
@@ -136,11 +140,15 @@ var _ = Describe("NodePublishVolume [Node Server]", func() {
 
 	It("should fail when no target path is provided", func() {
 
-		_, err := c.NodePublishVolume(
-			context.Background(),
-			&csi.NodePublishVolumeRequest{
-				VolumeId: "id",
-			})
+		req := &csi.NodePublishVolumeRequest{
+			VolumeId: "id",
+		}
+
+		if secrets != nil {
+			req.NodePublishSecrets = secrets.NodePublishVolumeSecret
+		}
+
+		_, err := c.NodePublishVolume(context.Background(), req)
 		Expect(err).To(HaveOccurred())
 
 		serverError, ok := status.FromError(err)
@@ -150,12 +158,16 @@ var _ = Describe("NodePublishVolume [Node Server]", func() {
 
 	It("should fail when no volume capability is provided", func() {
 
-		_, err := c.NodePublishVolume(
-			context.Background(),
-			&csi.NodePublishVolumeRequest{
-				VolumeId:   "id",
-				TargetPath: config.TargetPath,
-			})
+		req := &csi.NodePublishVolumeRequest{
+			VolumeId:   "id",
+			TargetPath: config.TargetPath,
+		}
+
+		if secrets != nil {
+			req.NodePublishSecrets = secrets.NodePublishVolumeSecret
+		}
+
+		_, err := c.NodePublishVolume(context.Background(), req)
 		Expect(err).To(HaveOccurred())
 
 		serverError, ok := status.FromError(err)
@@ -225,21 +237,25 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 	// Create Volume First
 	By("creating a single node writer volume")
 	name := "sanity"
-	vol, err := s.CreateVolume(
-		context.Background(),
-		&csi.CreateVolumeRequest{
-			Name: name,
-			VolumeCapabilities: []*csi.VolumeCapability{
-				{
-					AccessType: &csi.VolumeCapability_Mount{
-						Mount: &csi.VolumeCapability_MountVolume{},
-					},
-					AccessMode: &csi.VolumeCapability_AccessMode{
-						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-					},
+	req := &csi.CreateVolumeRequest{
+		Name: name,
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{
+				AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{},
+				},
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
 				},
 			},
-		})
+		},
+	}
+
+	if secrets != nil {
+		req.ControllerCreateSecrets = secrets.CreateVolumeSecret
+	}
+
+	vol, err := s.CreateVolume(context.Background(), req)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(vol).NotTo(BeNil())
 	Expect(vol.GetVolume()).NotTo(BeNil())
@@ -255,21 +271,26 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 	var conpubvol *csi.ControllerPublishVolumeResponse
 	if controllerPublishSupported {
 		By("controller publishing volume")
-		conpubvol, err = s.ControllerPublishVolume(
-			context.Background(),
-			&csi.ControllerPublishVolumeRequest{
-				VolumeId: vol.GetVolume().GetId(),
-				NodeId:   nid.GetNodeId(),
-				VolumeCapability: &csi.VolumeCapability{
-					AccessType: &csi.VolumeCapability_Mount{
-						Mount: &csi.VolumeCapability_MountVolume{},
-					},
-					AccessMode: &csi.VolumeCapability_AccessMode{
-						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-					},
+
+		pubReq := &csi.ControllerPublishVolumeRequest{
+			VolumeId: vol.GetVolume().GetId(),
+			NodeId:   nid.GetNodeId(),
+			VolumeCapability: &csi.VolumeCapability{
+				AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{},
 				},
-				Readonly: false,
-			})
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				},
+			},
+			Readonly: false,
+		}
+
+		if secrets != nil {
+			pubReq.ControllerPublishSecrets = secrets.ControllerPublishVolumeSecret
+		}
+
+		conpubvol, err = s.ControllerPublishVolume(context.Background(), pubReq)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(conpubvol).NotTo(BeNil())
 	}
@@ -290,6 +311,9 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 		}
 		if controllerPublishSupported {
 			nodeStageVolReq.PublishInfo = conpubvol.GetPublishInfo()
+		}
+		if secrets != nil {
+			nodeStageVolReq.NodeStageSecrets = secrets.NodeStageVolumeSecret
 		}
 		nodestagevol, err := c.NodeStageVolume(
 			context.Background(), nodeStageVolReq)
@@ -315,6 +339,9 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 	}
 	if controllerPublishSupported {
 		nodepubvolRequest.PublishInfo = conpubvol.GetPublishInfo()
+	}
+	if secrets != nil {
+		nodepubvolRequest.NodePublishSecrets = secrets.NodePublishVolumeSecret
 	}
 	nodepubvol, err := c.NodePublishVolume(context.Background(), nodepubvolRequest)
 	Expect(err).NotTo(HaveOccurred())
@@ -346,22 +373,32 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 
 	if controllerPublishSupported {
 		By("cleaning up calling controllerunpublishing")
-		controllerunpubvol, err := s.ControllerUnpublishVolume(
-			context.Background(),
-			&csi.ControllerUnpublishVolumeRequest{
-				VolumeId: vol.GetVolume().GetId(),
-				NodeId:   nid.GetNodeId(),
-			})
+
+		unpubReq := &csi.ControllerUnpublishVolumeRequest{
+			VolumeId: vol.GetVolume().GetId(),
+			NodeId:   nid.GetNodeId(),
+		}
+
+		if secrets != nil {
+			unpubReq.ControllerUnpublishSecrets = secrets.ControllerUnpublishVolumeSecret
+		}
+
+		controllerunpubvol, err := s.ControllerUnpublishVolume(context.Background(), unpubReq)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(controllerunpubvol).NotTo(BeNil())
 	}
 
 	By("cleaning up deleting the volume")
-	_, err = s.DeleteVolume(
-		context.Background(),
-		&csi.DeleteVolumeRequest{
-			VolumeId: vol.GetVolume().GetId(),
-		})
+
+	delReq := &csi.DeleteVolumeRequest{
+		VolumeId: vol.GetVolume().GetId(),
+	}
+
+	if secrets != nil {
+		delReq.ControllerDeleteSecrets = secrets.DeleteVolumeSecret
+	}
+
+	_, err = s.DeleteVolume(context.Background(), delReq)
 	Expect(err).NotTo(HaveOccurred())
 }
 
@@ -392,22 +429,26 @@ var _ = Describe("NodeStageVolume [Node Server]", func() {
 
 	It("should fail when no volume id is provided", func() {
 
-		_, err := c.NodeStageVolume(
-			context.Background(),
-			&csi.NodeStageVolumeRequest{
-				StagingTargetPath: config.StagingPath,
-				VolumeCapability: &csi.VolumeCapability{
-					AccessType: &csi.VolumeCapability_Mount{
-						Mount: &csi.VolumeCapability_MountVolume{},
-					},
-					AccessMode: &csi.VolumeCapability_AccessMode{
-						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-					},
+		req := &csi.NodeStageVolumeRequest{
+			StagingTargetPath: config.StagingPath,
+			VolumeCapability: &csi.VolumeCapability{
+				AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{},
 				},
-				PublishInfo: map[string]string{
-					"device": device,
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
 				},
-			})
+			},
+			PublishInfo: map[string]string{
+				"device": device,
+			},
+		}
+
+		if secrets != nil {
+			req.NodeStageSecrets = secrets.NodeStageVolumeSecret
+		}
+
+		_, err := c.NodeStageVolume(context.Background(), req)
 		Expect(err).To(HaveOccurred())
 
 		serverError, ok := status.FromError(err)
@@ -417,22 +458,26 @@ var _ = Describe("NodeStageVolume [Node Server]", func() {
 
 	It("should fail when no staging target path is provided", func() {
 
-		_, err := c.NodeStageVolume(
-			context.Background(),
-			&csi.NodeStageVolumeRequest{
-				VolumeId: "id",
-				VolumeCapability: &csi.VolumeCapability{
-					AccessType: &csi.VolumeCapability_Mount{
-						Mount: &csi.VolumeCapability_MountVolume{},
-					},
-					AccessMode: &csi.VolumeCapability_AccessMode{
-						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-					},
+		req := &csi.NodeStageVolumeRequest{
+			VolumeId: "id",
+			VolumeCapability: &csi.VolumeCapability{
+				AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{},
 				},
-				PublishInfo: map[string]string{
-					"device": device,
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
 				},
-			})
+			},
+			PublishInfo: map[string]string{
+				"device": device,
+			},
+		}
+
+		if secrets != nil {
+			req.NodeStageSecrets = secrets.NodeStageVolumeSecret
+		}
+
+		_, err := c.NodeStageVolume(context.Background(), req)
 		Expect(err).To(HaveOccurred())
 
 		serverError, ok := status.FromError(err)
@@ -442,15 +487,19 @@ var _ = Describe("NodeStageVolume [Node Server]", func() {
 
 	It("should fail when no volume capability is provided", func() {
 
-		_, err := c.NodeStageVolume(
-			context.Background(),
-			&csi.NodeStageVolumeRequest{
-				VolumeId:          "id",
-				StagingTargetPath: config.StagingPath,
-				PublishInfo: map[string]string{
-					"device": device,
-				},
-			})
+		req := &csi.NodeStageVolumeRequest{
+			VolumeId:          "id",
+			StagingTargetPath: config.StagingPath,
+			PublishInfo: map[string]string{
+				"device": device,
+			},
+		}
+
+		if secrets != nil {
+			req.NodeStageSecrets = secrets.NodeStageVolumeSecret
+		}
+
+		_, err := c.NodeStageVolume(context.Background(), req)
 		Expect(err).To(HaveOccurred())
 
 		serverError, ok := status.FromError(err)

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -18,11 +18,13 @@ package sanity
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"sync"
 	"testing"
 
 	"github.com/kubernetes-csi/csi-test/utils"
+	yaml "gopkg.in/yaml.v2"
 
 	"google.golang.org/grpc"
 
@@ -30,10 +32,21 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// CSISecrets consists of secrets used in CSI credentials.
+type CSISecrets struct {
+	CreateVolumeSecret              map[string]string `yaml:"CreateVolumeSecret"`
+	DeleteVolumeSecret              map[string]string `yaml:"DeleteVolumeSecret"`
+	ControllerPublishVolumeSecret   map[string]string `yaml:"ControllerPublishVolumeSecret"`
+	ControllerUnpublishVolumeSecret map[string]string `yaml:"ControllerUnpublishVolumeSecret"`
+	NodeStageVolumeSecret           map[string]string `yaml:"NodeStageVolumeSecret"`
+	NodePublishVolumeSecret         map[string]string `yaml:"NodePublishVolumeSecret"`
+}
+
 var (
-	config *Config
-	conn   *grpc.ClientConn
-	lock   sync.Mutex
+	config  *Config
+	conn    *grpc.ClientConn
+	lock    sync.Mutex
+	secrets *CSISecrets
 )
 
 // Config provides the configuration for the sanity tests
@@ -41,6 +54,7 @@ type Config struct {
 	TargetPath  string
 	StagingPath string
 	Address     string
+	SecretsFile string
 }
 
 // Test will test the CSI driver at the specified address
@@ -55,6 +69,11 @@ func Test(t *testing.T, reqConfig *Config) {
 
 var _ = BeforeSuite(func() {
 	var err error
+
+	if len(config.SecretsFile) > 0 {
+		secrets, err = loadSecrets(config.SecretsFile)
+		Expect(err).NotTo(HaveOccurred())
+	}
 
 	By("connecting to CSI driver")
 	conn, err = utils.Connect(config.Address)
@@ -85,4 +104,20 @@ func createMountTargetLocation(targetPath string) error {
 	}
 
 	return nil
+}
+
+func loadSecrets(path string) (*CSISecrets, error) {
+	var creds CSISecrets
+
+	yamlFile, err := ioutil.ReadFile(path)
+	if err != nil {
+		return &creds, fmt.Errorf("failed to read file %q: #%v", path, err)
+	}
+
+	err = yaml.Unmarshal(yamlFile, &creds)
+	if err != nil {
+		return &creds, fmt.Errorf("error unmarshaling yaml: #%v", err)
+	}
+
+	return &creds, nil
 }


### PR DESCRIPTION
Adds auth interceptor in mock driver to check the passed credentials.

Adds secrets support in csi-sanity via yaml file with secret config.

Inserts secrets in all the test request when secrets are defined.

Runs the whole e2e test suite second time with credentials set.

Fixes #47 