### PR TITLE
sanity: Add more ControllerPublishVolume tests

### DIFF
--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -806,6 +806,212 @@ var _ = Describe("ControllerPublishVolume [Controller Server]", func() {
 		_, err = c.DeleteVolume(context.Background(), delReq)
 		Expect(err).NotTo(HaveOccurred())
 	})
+
+	It("should fail when the volume does not exist", func() {
+
+		By("calling controller publish on a non-existent volume")
+
+		pubReq := &csi.ControllerPublishVolumeRequest{
+			VolumeId: "some-vol-id",
+			NodeId:   "some-node-id",
+			VolumeCapability: &csi.VolumeCapability{
+				AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{},
+				},
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				},
+			},
+			Readonly: false,
+		}
+
+		if secrets != nil {
+			pubReq.ControllerPublishSecrets = secrets.ControllerPublishVolumeSecret
+		}
+
+		conpubvol, err := c.ControllerPublishVolume(context.Background(), pubReq)
+		Expect(err).To(HaveOccurred())
+		Expect(conpubvol).To(BeNil())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.NotFound))
+	})
+
+	It("should fail when the node does not exist", func() {
+
+		// Create Volume First
+		By("creating a single node writer volume")
+		name := "sanity"
+		req := &csi.CreateVolumeRequest{
+			Name: name,
+			VolumeCapabilities: []*csi.VolumeCapability{
+				{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+			},
+		}
+
+		if secrets != nil {
+			req.ControllerCreateSecrets = secrets.CreateVolumeSecret
+		}
+
+		vol, err := c.CreateVolume(context.Background(), req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(vol).NotTo(BeNil())
+		Expect(vol.GetVolume()).NotTo(BeNil())
+		Expect(vol.GetVolume().GetId()).NotTo(BeEmpty())
+
+		// ControllerPublishVolume
+		By("calling controllerpublish on that volume")
+
+		pubReq := &csi.ControllerPublishVolumeRequest{
+			VolumeId: vol.GetVolume().GetId(),
+			NodeId:   "some-fake-node-id",
+			VolumeCapability: &csi.VolumeCapability{
+				AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{},
+				},
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				},
+			},
+			Readonly: false,
+		}
+
+		if secrets != nil {
+			pubReq.ControllerPublishSecrets = secrets.ControllerPublishVolumeSecret
+		}
+
+		conpubvol, err := c.ControllerPublishVolume(context.Background(), pubReq)
+		Expect(err).To(HaveOccurred())
+		Expect(conpubvol).To(BeNil())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.NotFound))
+
+		By("cleaning up deleting the volume")
+
+		delReq := &csi.DeleteVolumeRequest{
+			VolumeId: vol.GetVolume().GetId(),
+		}
+
+		if secrets != nil {
+			delReq.ControllerDeleteSecrets = secrets.DeleteVolumeSecret
+		}
+
+		_, err = c.DeleteVolume(context.Background(), delReq)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should fail when the volume is already published but is incompatible", func() {
+
+		// Create Volume First
+		By("creating a single node writer volume")
+		name := "sanity"
+		req := &csi.CreateVolumeRequest{
+			Name: name,
+			VolumeCapabilities: []*csi.VolumeCapability{
+				{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+			},
+		}
+
+		if secrets != nil {
+			req.ControllerCreateSecrets = secrets.CreateVolumeSecret
+		}
+
+		vol, err := c.CreateVolume(context.Background(), req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(vol).NotTo(BeNil())
+		Expect(vol.GetVolume()).NotTo(BeNil())
+		Expect(vol.GetVolume().GetId()).NotTo(BeEmpty())
+
+		By("getting a node id")
+		nid, err := n.NodeGetId(
+			context.Background(),
+			&csi.NodeGetIdRequest{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nid).NotTo(BeNil())
+		Expect(nid.GetNodeId()).NotTo(BeEmpty())
+
+		// ControllerPublishVolume
+		By("calling controllerpublish on that volume")
+
+		pubReq := &csi.ControllerPublishVolumeRequest{
+			VolumeId: vol.GetVolume().GetId(),
+			NodeId:   nid.GetNodeId(),
+			VolumeCapability: &csi.VolumeCapability{
+				AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{},
+				},
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				},
+			},
+			Readonly: false,
+		}
+
+		if secrets != nil {
+			pubReq.ControllerPublishSecrets = secrets.ControllerPublishVolumeSecret
+		}
+
+		conpubvol, err := c.ControllerPublishVolume(context.Background(), pubReq)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(conpubvol).NotTo(BeNil())
+
+		// Publish again with different attributes.
+		pubReq.Readonly = true
+
+		conpubvol, err = c.ControllerPublishVolume(context.Background(), pubReq)
+		Expect(err).To(HaveOccurred())
+		Expect(conpubvol).To(BeNil())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.AlreadyExists))
+
+		By("cleaning up unpublishing the volume")
+
+		unpubReq := &csi.ControllerUnpublishVolumeRequest{
+			VolumeId: vol.GetVolume().GetId(),
+			// NodeID is optional in ControllerUnpublishVolume
+			NodeId: nid.GetNodeId(),
+		}
+
+		if secrets != nil {
+			unpubReq.ControllerUnpublishSecrets = secrets.ControllerUnpublishVolumeSecret
+		}
+
+		conunpubvol, err := c.ControllerUnpublishVolume(context.Background(), unpubReq)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(conunpubvol).NotTo(BeNil())
+
+		By("cleaning up deleting the volume")
+
+		delReq := &csi.DeleteVolumeRequest{
+			VolumeId: vol.GetVolume().GetId(),
+		}
+
+		if secrets != nil {
+			delReq.ControllerDeleteSecrets = secrets.DeleteVolumeSecret
+		}
+
+		_, err = c.DeleteVolume(context.Background(), delReq)
+		Expect(err).NotTo(HaveOccurred())
+	})
 })
 
 var _ = Describe("ControllerUnpublishVolume [Controller Server]", func() {


### PR DESCRIPTION
Adds tests for:
* should fail when the volume does not exist
* should fail when the node does not exist
* should fail when the volume is already published but is incompatible

Also, modifies mock driver to contain readonly volume information.