### PR TITLE
Mock driver: Return probe ready status

### DIFF
--- a/mock/service/identity.go
+++ b/mock/service/identity.go
@@ -4,6 +4,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/golang/protobuf/ptypes/wrappers"
 )
 
 func (s *service) GetPluginInfo(
@@ -23,7 +24,9 @@ func (s *service) Probe(
 	req *csi.ProbeRequest) (
 	*csi.ProbeResponse, error) {
 
-	return &csi.ProbeResponse{}, nil
+	return &csi.ProbeResponse{
+		Ready: &wrappers.BoolValue{Value: true},
+	}, nil
 }
 
 func (s *service) GetPluginCapabilities(

--- a/pkg/sanity/identity.go
+++ b/pkg/sanity/identity.go
@@ -79,6 +79,11 @@ var _ = Describe("Probe [Identity Service]", func() {
 		Expect(ok).To(BeTrue())
 		Expect(serverError.Code() == codes.FailedPrecondition ||
 			serverError.Code() == codes.OK).To(BeTrue())
+
+		if res.GetReady() != nil {
+			Expect(res.GetReady().GetValue() == true ||
+				res.GetReady().GetValue() == false).To(BeTrue())
+		}
 	})
 })
 


### PR DESCRIPTION
CSI 0.3.0 introduced probe ready status. This change adds the Ready
value in ProbeResponse.