### PR TITLE
sanity: test NodeGetInfo() & accessibility capability

### DIFF
--- a/pkg/sanity/identity.go
+++ b/pkg/sanity/identity.go
@@ -50,6 +50,7 @@ var _ = Describe("GetPluginCapabilities [Identity Service]", func() {
 		for _, cap := range res.GetCapabilities() {
 			switch cap.GetService().GetType() {
 			case csi.PluginCapability_Service_CONTROLLER_SERVICE:
+			case csi.PluginCapability_Service_ACCESSIBILITY_CONSTRAINTS:
 			default:
 				Fail(fmt.Sprintf("Unknown capability: %v\n", cap.GetService().GetType()))
 			}


### PR DESCRIPTION
* Adds test for NodeGetInfo()
* Adds ACCESSIBILITY_CONSTRAINT plugin capability in the known plugin
capability list.
* Adds isPluginCapabilitySupported() to check if the
ACCESSIBILITY_CONSTRAINT plugin capability is supported.