### PR TITLE
Add test for ControllerPublishVolume

### DIFF
--- a/test/co_test.go
+++ b/test/co_test.go
@@ -16,10 +16,13 @@ limitations under the License.
 package test
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
 	gomock "github.com/golang/mock/gomock"
+	"github.com/golang/protobuf/proto"
 	mock_driver "github.com/kubernetes-csi/csi-test/driver"
 	mock_utils "github.com/kubernetes-csi/csi-test/utils"
 	"golang.org/x/net/context"
@@ -58,6 +61,24 @@ func TestPluginInfoResponse(t *testing.T) {
 	}
 }
 
+type pbMatcher struct {
+	x proto.Message
+}
+
+func (p pbMatcher) Matches(x interface{}) bool {
+	y := x.(proto.Message)
+	return proto.Equal(p.x, y)
+}
+
+func (p pbMatcher) String() string {
+	return fmt.Sprintf("pb equal to %v", p.x)
+}
+
+func pbMatch(x interface{}) gomock.Matcher {
+	v := x.(proto.Message)
+	return &pbMatcher{v}
+}
+
 func TestGRPCGetPluginInfoReponse(t *testing.T) {
 
 	// Setup mock
@@ -79,7 +100,7 @@ func TestGRPCGetPluginInfoReponse(t *testing.T) {
 
 	// Setup expectation
 	// !IMPORTANT!: Must set context expected value to gomock.Any() to match any value
-	driver.EXPECT().GetPluginInfo(gomock.Any(), in).Return(out, nil).Times(1)
+	driver.EXPECT().GetPluginInfo(gomock.Any(), pbMatch(in)).Return(out, nil).Times(1)
 
 	// Create a new RPC
 	server := mock_driver.NewMockCSIDriver(&mock_driver.MockCSIDriverServers{
@@ -101,5 +122,67 @@ func TestGRPCGetPluginInfoReponse(t *testing.T) {
 	name := r.GetName()
 	if name != "mock" {
 		t.Errorf("Unknown name: %s\n", name)
+	}
+}
+
+func TestGRPCAttach(t *testing.T) {
+
+	// Setup mock
+	m := gomock.NewController(&mock_utils.SafeGoroutineTester{})
+	defer m.Finish()
+	driver := mock_driver.NewMockControllerServer(m)
+
+	// Setup input
+	defaultVolumeID := "myname"
+	defaultNodeID := "MyNodeID"
+	defaultCaps := &csi.VolumeCapability{
+		AccessType: &csi.VolumeCapability_Mount{
+			Mount: &csi.VolumeCapability_MountVolume{},
+		},
+		AccessMode: &csi.VolumeCapability_AccessMode{
+			Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+		},
+	}
+	publishVolumeInfo := map[string]string{
+		"first":  "foo",
+		"second": "bar",
+		"third":  "baz",
+	}
+	defaultRequest := &csi.ControllerPublishVolumeRequest{
+		VolumeId:         defaultVolumeID,
+		NodeId:           defaultNodeID,
+		VolumeCapability: defaultCaps,
+		Readonly:         false,
+	}
+
+	// Setup mock outout
+	out := &csi.ControllerPublishVolumeResponse{
+		PublishInfo: publishVolumeInfo,
+	}
+
+	// Setup expectation
+	// !IMPORTANT!: Must set context expected value to gomock.Any() to match any value
+	driver.EXPECT().ControllerPublishVolume(gomock.Any(), pbMatch(defaultRequest)).Return(out, nil).Times(1)
+
+	// Create a new RPC
+	server := mock_driver.NewMockCSIDriver(&mock_driver.MockCSIDriverServers{
+		Controller: driver,
+	})
+	conn, err := server.Nexus()
+	if err != nil {
+		t.Errorf("Error: %s", err.Error())
+	}
+	defer server.Close()
+
+	// Make call
+	c := csi.NewControllerClient(conn)
+	r, err := c.ControllerPublishVolume(context.Background(), defaultRequest)
+	if err != nil {
+		t.Errorf("Error: %s", err.Error())
+	}
+
+	info := r.GetPublishInfo()
+	if !reflect.DeepEqual(info, publishVolumeInfo) {
+		t.Errorf("Invalid publish info: %v", info)
 	}
 }


### PR DESCRIPTION
I'm opening this PR to demonstrate an error I am seeing with `csi-test` master. When updating the CSI external attacher/detacher, I always get a test failure for ControllerPublishVolume. In fact it hangs - took a while to track it down to this.

The `reflect.DeepEqual` that `gomock` performs to check for object equivalence is failing for the `ControllerPublishVolume` input. Oddly, it is *only* that call that fails - all the other tests pass. For simplicity, I added a test here in `csi-test` that demonstrates it.

When the test fails, you will see the following:
```
Unexpected call to *driver.MockControllerServer.ControllerPublishVolume([context.Background.WithCancel.WithCancel.WithValue(peer.peerKey{}, &peer.Peer{Addr:(*net.TCPAddr)(0xc4201b0c60), AuthInfo:credentials.AuthInfo(nil)}).WithValue(metadata.mdIncomingKey{}, metadata.MD{":authority":[]string{"127.0.0.1:51284"}, "content-type":[]string{"application/grpc"}, "user-agent":[]string{"grpc-go/1.12.2"}}).WithValue(grpc.streamKey{}, <stream: 0xc42032a000, /csi.v0.Controller/ControllerPublishVolume>) volume_id:"myname" node_id:"MyNodeID" volume_capability:<mount:<> access_mode:<mode:MULTI_NODE_MULTI_WRITER > > ]) at /Users/trhoden/go/src/github.com/kubernetes-csi/csi-test/driver/driver.mock.go:522 because:
Expected call at /Users/trhoden/go/src/github.com/kubernetes-csi/csi-test/driver/driver.mock.go:529 doesn't match the argument at index 1.
Got: volume_id:"myname" node_id:"MyNodeID" volume_capability:<mount:<> access_mode:<mode:MULTI_NODE_MULTI_WRITER > >
Want: is equal to volume_id:"myname" node_id:"MyNodeID" volume_capability:<mount:<> access_mode:<mode:MULTI_NODE_MULTI_WRITER > >
panic: MOCK TEST FATAL FAILURE
```

Note that the Expected and Got lines show the object is correct, but it is not being picked up that way. I've tried using different versions of `gomock`, `grpc`, regenerating the mock objects, etc., but haven't gotten around this one yet. Help is appreciated!