### PR TITLE
pkg/sanity: support sanity testing in another Ginkgo suite

### DIFF
--- a/pkg/sanity/README.md
+++ b/pkg/sanity/README.md
@@ -13,12 +13,49 @@ Golang `TestXXX` functions. For example:
 
 ```go
 func TestMyDriver(t *testing.T) {
-    // Setup the full driver and its environment
-    ... setup driver ...
+	// Setup the full driver and its environment
+	... setup driver ...
+	config := &sanity.Config{
+		TargetPath:     ...
+		StagingPath:    ...
+		Address:        endpoint,
+	}
 
-    // Now call the test suite
-    sanity.Test(t, driverEndpointAddress, "/mnt")
+
+	// Now call the test suite
+	sanity.Test(t, config)
 }
+```
+
+Only one such test function is supported because under the hood a
+Ginkgo test suite gets constructed and executed by the call.
+
+Alternatively, the tests can also be embedded inside a Ginkgo test
+suite. In that case it is possible to define multiple tests with
+different configurations:
+
+```go
+var _ = Describe("MyCSIDriver", func () {
+	Context("Config A", func () {
+		var config &sanity.Config
+
+		BeforeEach() {
+			... setup driver and config...
+		}
+
+		AfterEach() {
+			...tear down driver...
+		}
+
+		Describe("CSI sanity", func() {
+			sanity.GinkgoTest(config)
+		})
+	})
+
+	Context("Config B", func () {
+		...
+	})
+})
 ```
 
 ## Command line program

--- a/pkg/sanity/identity.go
+++ b/pkg/sanity/identity.go
@@ -30,13 +30,13 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("GetPluginCapabilities [Identity Service]", func() {
+var _ = DescribeSanity("GetPluginCapabilities [Identity Service]", func(sc *SanityContext) {
 	var (
 		c csi.IdentityClient
 	)
 
 	BeforeEach(func() {
-		c = csi.NewIdentityClient(conn)
+		c = csi.NewIdentityClient(sc.Conn)
 	})
 
 	It("should return appropriate capabilities", func() {
@@ -60,13 +60,13 @@ var _ = Describe("GetPluginCapabilities [Identity Service]", func() {
 
 })
 
-var _ = Describe("Probe [Identity Service]", func() {
+var _ = DescribeSanity("Probe [Identity Service]", func(sc *SanityContext) {
 	var (
 		c csi.IdentityClient
 	)
 
 	BeforeEach(func() {
-		c = csi.NewIdentityClient(conn)
+		c = csi.NewIdentityClient(sc.Conn)
 	})
 
 	It("should return appropriate information", func() {
@@ -88,13 +88,13 @@ var _ = Describe("Probe [Identity Service]", func() {
 	})
 })
 
-var _ = Describe("GetPluginInfo [Identity Server]", func() {
+var _ = DescribeSanity("GetPluginInfo [Identity Server]", func(sc *SanityContext) {
 	var (
 		c csi.IdentityClient
 	)
 
 	BeforeEach(func() {
-		c = csi.NewIdentityClient(conn)
+		c = csi.NewIdentityClient(sc.Conn)
 	})
 
 	It("should return appropriate information", func() {

--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -69,13 +69,13 @@ func isPluginCapabilitySupported(c csi.IdentityClient,
 	return false
 }
 
-var _ = Describe("NodeGetCapabilities [Node Server]", func() {
+var _ = DescribeSanity("NodeGetCapabilities [Node Server]", func(sc *SanityContext) {
 	var (
 		c csi.NodeClient
 	)
 
 	BeforeEach(func() {
-		c = csi.NewNodeClient(conn)
+		c = csi.NewNodeClient(sc.Conn)
 	})
 
 	It("should return appropriate capabilities", func() {
@@ -101,13 +101,13 @@ var _ = Describe("NodeGetCapabilities [Node Server]", func() {
 	})
 })
 
-var _ = Describe("NodeGetId [Node Server]", func() {
+var _ = DescribeSanity("NodeGetId [Node Server]", func(sc *SanityContext) {
 	var (
 		c csi.NodeClient
 	)
 
 	BeforeEach(func() {
-		c = csi.NewNodeClient(conn)
+		c = csi.NewNodeClient(sc.Conn)
 	})
 
 	It("should return appropriate values", func() {
@@ -121,7 +121,7 @@ var _ = Describe("NodeGetId [Node Server]", func() {
 	})
 })
 
-var _ = Describe("NodeGetInfo [Node Server]", func() {
+var _ = DescribeSanity("NodeGetInfo [Node Server]", func(sc *SanityContext) {
 	var (
 		c                                csi.NodeClient
 		i                                csi.IdentityClient
@@ -129,8 +129,8 @@ var _ = Describe("NodeGetInfo [Node Server]", func() {
 	)
 
 	BeforeEach(func() {
-		c = csi.NewNodeClient(conn)
-		i = csi.NewIdentityClient(conn)
+		c = csi.NewNodeClient(sc.Conn)
+		i = csi.NewIdentityClient(sc.Conn)
 		accessibilityConstraintSupported = isPluginCapabilitySupported(i, csi.PluginCapability_Service_ACCESSIBILITY_CONSTRAINTS)
 	})
 
@@ -150,7 +150,7 @@ var _ = Describe("NodeGetInfo [Node Server]", func() {
 	})
 })
 
-var _ = Describe("NodePublishVolume [Node Server]", func() {
+var _ = DescribeSanity("NodePublishVolume [Node Server]", func(sc *SanityContext) {
 	var (
 		s                          csi.ControllerClient
 		c                          csi.NodeClient
@@ -159,14 +159,14 @@ var _ = Describe("NodePublishVolume [Node Server]", func() {
 	)
 
 	BeforeEach(func() {
-		s = csi.NewControllerClient(conn)
-		c = csi.NewNodeClient(conn)
+		s = csi.NewControllerClient(sc.Conn)
+		c = csi.NewNodeClient(sc.Conn)
 		controllerPublishSupported = isControllerCapabilitySupported(
 			s,
 			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME)
 		nodeStageSupported = isNodeCapabilitySupported(c, csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME)
 		if nodeStageSupported {
-			err := createMountTargetLocation(config.StagingPath)
+			err := createMountTargetLocation(sc.Config.StagingPath)
 			Expect(err).NotTo(HaveOccurred())
 		}
 	})
@@ -175,8 +175,8 @@ var _ = Describe("NodePublishVolume [Node Server]", func() {
 
 		req := &csi.NodePublishVolumeRequest{}
 
-		if secrets != nil {
-			req.NodePublishSecrets = secrets.NodePublishVolumeSecret
+		if sc.Secrets != nil {
+			req.NodePublishSecrets = sc.Secrets.NodePublishVolumeSecret
 		}
 
 		_, err := c.NodePublishVolume(context.Background(), req)
@@ -193,8 +193,8 @@ var _ = Describe("NodePublishVolume [Node Server]", func() {
 			VolumeId: "id",
 		}
 
-		if secrets != nil {
-			req.NodePublishSecrets = secrets.NodePublishVolumeSecret
+		if sc.Secrets != nil {
+			req.NodePublishSecrets = sc.Secrets.NodePublishVolumeSecret
 		}
 
 		_, err := c.NodePublishVolume(context.Background(), req)
@@ -209,11 +209,11 @@ var _ = Describe("NodePublishVolume [Node Server]", func() {
 
 		req := &csi.NodePublishVolumeRequest{
 			VolumeId:   "id",
-			TargetPath: config.TargetPath,
+			TargetPath: sc.Config.TargetPath,
 		}
 
-		if secrets != nil {
-			req.NodePublishSecrets = secrets.NodePublishVolumeSecret
+		if sc.Secrets != nil {
+			req.NodePublishSecrets = sc.Secrets.NodePublishVolumeSecret
 		}
 
 		_, err := c.NodePublishVolume(context.Background(), req)
@@ -225,11 +225,11 @@ var _ = Describe("NodePublishVolume [Node Server]", func() {
 	})
 
 	It("should return appropriate values (no optional values added)", func() {
-		testFullWorkflowSuccess(s, c, controllerPublishSupported, nodeStageSupported)
+		testFullWorkflowSuccess(sc, s, c, controllerPublishSupported, nodeStageSupported)
 	})
 })
 
-var _ = Describe("NodeUnpublishVolume [Node Server]", func() {
+var _ = DescribeSanity("NodeUnpublishVolume [Node Server]", func(sc *SanityContext) {
 	var (
 		s                          csi.ControllerClient
 		c                          csi.NodeClient
@@ -238,14 +238,14 @@ var _ = Describe("NodeUnpublishVolume [Node Server]", func() {
 	)
 
 	BeforeEach(func() {
-		s = csi.NewControllerClient(conn)
-		c = csi.NewNodeClient(conn)
+		s = csi.NewControllerClient(sc.Conn)
+		c = csi.NewNodeClient(sc.Conn)
 		controllerPublishSupported = isControllerCapabilitySupported(
 			s,
 			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME)
 		nodeStageSupported = isNodeCapabilitySupported(c, csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME)
 		if nodeStageSupported {
-			err := createMountTargetLocation(config.StagingPath)
+			err := createMountTargetLocation(sc.Config.StagingPath)
 			Expect(err).NotTo(HaveOccurred())
 		}
 	})
@@ -277,12 +277,12 @@ var _ = Describe("NodeUnpublishVolume [Node Server]", func() {
 	})
 
 	It("should return appropriate values (no optional values added)", func() {
-		testFullWorkflowSuccess(s, c, controllerPublishSupported, nodeStageSupported)
+		testFullWorkflowSuccess(sc, s, c, controllerPublishSupported, nodeStageSupported)
 	})
 })
 
 // TODO: Tests for NodeStageVolume/NodeUnstageVolume
-func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controllerPublishSupported, nodeStageSupported bool) {
+func testFullWorkflowSuccess(sc *SanityContext, s csi.ControllerClient, c csi.NodeClient, controllerPublishSupported, nodeStageSupported bool) {
 	// Create Volume First
 	By("creating a single node writer volume")
 	name := "sanity"
@@ -300,8 +300,8 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 		},
 	}
 
-	if secrets != nil {
-		req.ControllerCreateSecrets = secrets.CreateVolumeSecret
+	if sc.Secrets != nil {
+		req.ControllerCreateSecrets = sc.Secrets.CreateVolumeSecret
 	}
 
 	vol, err := s.CreateVolume(context.Background(), req)
@@ -335,8 +335,8 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 			Readonly: false,
 		}
 
-		if secrets != nil {
-			pubReq.ControllerPublishSecrets = secrets.ControllerPublishVolumeSecret
+		if sc.Secrets != nil {
+			pubReq.ControllerPublishSecrets = sc.Secrets.ControllerPublishVolumeSecret
 		}
 
 		conpubvol, err = s.ControllerPublishVolume(context.Background(), pubReq)
@@ -356,13 +356,13 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
 				},
 			},
-			StagingTargetPath: config.StagingPath,
+			StagingTargetPath: sc.Config.StagingPath,
 		}
 		if controllerPublishSupported {
 			nodeStageVolReq.PublishInfo = conpubvol.GetPublishInfo()
 		}
-		if secrets != nil {
-			nodeStageVolReq.NodeStageSecrets = secrets.NodeStageVolumeSecret
+		if sc.Secrets != nil {
+			nodeStageVolReq.NodeStageSecrets = sc.Secrets.NodeStageVolumeSecret
 		}
 		nodestagevol, err := c.NodeStageVolume(
 			context.Background(), nodeStageVolReq)
@@ -373,7 +373,7 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 	By("publishing the volume on a node")
 	nodepubvolRequest := &csi.NodePublishVolumeRequest{
 		VolumeId:   vol.GetVolume().GetId(),
-		TargetPath: config.TargetPath,
+		TargetPath: sc.Config.TargetPath,
 		VolumeCapability: &csi.VolumeCapability{
 			AccessType: &csi.VolumeCapability_Mount{
 				Mount: &csi.VolumeCapability_MountVolume{},
@@ -384,13 +384,13 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 		},
 	}
 	if nodeStageSupported {
-		nodepubvolRequest.StagingTargetPath = config.StagingPath
+		nodepubvolRequest.StagingTargetPath = sc.Config.StagingPath
 	}
 	if controllerPublishSupported {
 		nodepubvolRequest.PublishInfo = conpubvol.GetPublishInfo()
 	}
-	if secrets != nil {
-		nodepubvolRequest.NodePublishSecrets = secrets.NodePublishVolumeSecret
+	if sc.Secrets != nil {
+		nodepubvolRequest.NodePublishSecrets = sc.Secrets.NodePublishVolumeSecret
 	}
 	nodepubvol, err := c.NodePublishVolume(context.Background(), nodepubvolRequest)
 	Expect(err).NotTo(HaveOccurred())
@@ -402,7 +402,7 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 		context.Background(),
 		&csi.NodeUnpublishVolumeRequest{
 			VolumeId:   vol.GetVolume().GetId(),
-			TargetPath: config.TargetPath,
+			TargetPath: sc.Config.TargetPath,
 		})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(nodeunpubvol).NotTo(BeNil())
@@ -413,7 +413,7 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 			context.Background(),
 			&csi.NodeUnstageVolumeRequest{
 				VolumeId:          vol.GetVolume().GetId(),
-				StagingTargetPath: config.StagingPath,
+				StagingTargetPath: sc.Config.StagingPath,
 			},
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -428,8 +428,8 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 			NodeId:   nid.GetNodeId(),
 		}
 
-		if secrets != nil {
-			unpubReq.ControllerUnpublishSecrets = secrets.ControllerUnpublishVolumeSecret
+		if sc.Secrets != nil {
+			unpubReq.ControllerUnpublishSecrets = sc.Secrets.ControllerUnpublishVolumeSecret
 		}
 
 		controllerunpubvol, err := s.ControllerUnpublishVolume(context.Background(), unpubReq)
@@ -443,15 +443,15 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 		VolumeId: vol.GetVolume().GetId(),
 	}
 
-	if secrets != nil {
-		delReq.ControllerDeleteSecrets = secrets.DeleteVolumeSecret
+	if sc.Secrets != nil {
+		delReq.ControllerDeleteSecrets = sc.Secrets.DeleteVolumeSecret
 	}
 
 	_, err = s.DeleteVolume(context.Background(), delReq)
 	Expect(err).NotTo(HaveOccurred())
 }
 
-var _ = Describe("NodeStageVolume [Node Server]", func() {
+var _ = DescribeSanity("NodeStageVolume [Node Server]", func(sc *SanityContext) {
 	var (
 		s                          csi.ControllerClient
 		c                          csi.NodeClient
@@ -461,15 +461,15 @@ var _ = Describe("NodeStageVolume [Node Server]", func() {
 	)
 
 	BeforeEach(func() {
-		s = csi.NewControllerClient(conn)
-		c = csi.NewNodeClient(conn)
+		s = csi.NewControllerClient(sc.Conn)
+		c = csi.NewNodeClient(sc.Conn)
 		device = "/dev/mock"
 		controllerPublishSupported = isControllerCapabilitySupported(
 			s,
 			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME)
 		nodeStageSupported = isNodeCapabilitySupported(c, csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME)
 		if nodeStageSupported {
-			err := createMountTargetLocation(config.StagingPath)
+			err := createMountTargetLocation(sc.Config.StagingPath)
 			Expect(err).NotTo(HaveOccurred())
 		} else {
 			Skip("NodeStageVolume not supported")
@@ -479,7 +479,7 @@ var _ = Describe("NodeStageVolume [Node Server]", func() {
 	It("should fail when no volume id is provided", func() {
 
 		req := &csi.NodeStageVolumeRequest{
-			StagingTargetPath: config.StagingPath,
+			StagingTargetPath: sc.Config.StagingPath,
 			VolumeCapability: &csi.VolumeCapability{
 				AccessType: &csi.VolumeCapability_Mount{
 					Mount: &csi.VolumeCapability_MountVolume{},
@@ -493,8 +493,8 @@ var _ = Describe("NodeStageVolume [Node Server]", func() {
 			},
 		}
 
-		if secrets != nil {
-			req.NodeStageSecrets = secrets.NodeStageVolumeSecret
+		if sc.Secrets != nil {
+			req.NodeStageSecrets = sc.Secrets.NodeStageVolumeSecret
 		}
 
 		_, err := c.NodeStageVolume(context.Background(), req)
@@ -522,8 +522,8 @@ var _ = Describe("NodeStageVolume [Node Server]", func() {
 			},
 		}
 
-		if secrets != nil {
-			req.NodeStageSecrets = secrets.NodeStageVolumeSecret
+		if sc.Secrets != nil {
+			req.NodeStageSecrets = sc.Secrets.NodeStageVolumeSecret
 		}
 
 		_, err := c.NodeStageVolume(context.Background(), req)
@@ -538,14 +538,14 @@ var _ = Describe("NodeStageVolume [Node Server]", func() {
 
 		req := &csi.NodeStageVolumeRequest{
 			VolumeId:          "id",
-			StagingTargetPath: config.StagingPath,
+			StagingTargetPath: sc.Config.StagingPath,
 			PublishInfo: map[string]string{
 				"device": device,
 			},
 		}
 
-		if secrets != nil {
-			req.NodeStageSecrets = secrets.NodeStageVolumeSecret
+		if sc.Secrets != nil {
+			req.NodeStageSecrets = sc.Secrets.NodeStageVolumeSecret
 		}
 
 		_, err := c.NodeStageVolume(context.Background(), req)
@@ -557,11 +557,11 @@ var _ = Describe("NodeStageVolume [Node Server]", func() {
 	})
 
 	It("should return appropriate values (no optional values added)", func() {
-		testFullWorkflowSuccess(s, c, controllerPublishSupported, nodeStageSupported)
+		testFullWorkflowSuccess(sc, s, c, controllerPublishSupported, nodeStageSupported)
 	})
 })
 
-var _ = Describe("NodeUnstageVolume [Node Server]", func() {
+var _ = DescribeSanity("NodeUnstageVolume [Node Server]", func(sc *SanityContext) {
 	var (
 		s                          csi.ControllerClient
 		c                          csi.NodeClient
@@ -570,14 +570,14 @@ var _ = Describe("NodeUnstageVolume [Node Server]", func() {
 	)
 
 	BeforeEach(func() {
-		s = csi.NewControllerClient(conn)
-		c = csi.NewNodeClient(conn)
+		s = csi.NewControllerClient(sc.Conn)
+		c = csi.NewNodeClient(sc.Conn)
 		controllerPublishSupported = isControllerCapabilitySupported(
 			s,
 			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME)
 		nodeStageSupported = isNodeCapabilitySupported(c, csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME)
 		if nodeStageSupported {
-			err := createMountTargetLocation(config.StagingPath)
+			err := createMountTargetLocation(sc.Config.StagingPath)
 			Expect(err).NotTo(HaveOccurred())
 		} else {
 			Skip("NodeUnstageVolume not supported")
@@ -589,7 +589,7 @@ var _ = Describe("NodeUnstageVolume [Node Server]", func() {
 		_, err := c.NodeUnstageVolume(
 			context.Background(),
 			&csi.NodeUnstageVolumeRequest{
-				StagingTargetPath: config.StagingPath,
+				StagingTargetPath: sc.Config.StagingPath,
 			})
 		Expect(err).To(HaveOccurred())
 
@@ -613,6 +613,6 @@ var _ = Describe("NodeUnstageVolume [Node Server]", func() {
 	})
 
 	It("should return appropriate values (no optional values added)", func() {
-		testFullWorkflowSuccess(s, c, controllerPublishSupported, nodeStageSupported)
+		testFullWorkflowSuccess(sc, s, c, controllerPublishSupported, nodeStageSupported)
 	})
 })

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"sync"
 	"testing"
 
 	"github.com/kubernetes-csi/csi-test/utils"
@@ -42,14 +41,8 @@ type CSISecrets struct {
 	NodePublishVolumeSecret         map[string]string `yaml:"NodePublishVolumeSecret"`
 }
 
-var (
-	config  *Config
-	conn    *grpc.ClientConn
-	lock    sync.Mutex
-	secrets *CSISecrets
-)
-
-// Config provides the configuration for the sanity tests
+// Config provides the configuration for the sanity tests. It
+// needs to be initialized by the user of the sanity package.
 type Config struct {
 	TargetPath     string
 	StagingPath    string
@@ -58,40 +51,61 @@ type Config struct {
 	TestVolumeSize int64
 }
 
-// Test will test the CSI driver at the specified address
-func Test(t *testing.T, reqConfig *Config) {
-	lock.Lock()
-	defer lock.Unlock()
+// SanityContext holds the variables that each test can depend on. It
+// gets initialized before each test block runs.
+type SanityContext struct {
+	Config  *Config
+	Conn    *grpc.ClientConn
+	Secrets *CSISecrets
+}
 
-	config = reqConfig
+// Test will test the CSI driver at the specified address by
+// setting up a Ginkgo suite and running it.
+func Test(t *testing.T, reqConfig *Config) {
+	sc := &SanityContext{
+		Config: reqConfig,
+	}
+
+	registerTestsInGinkgo(sc)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CSI Driver Test Suite")
 }
 
-var _ = BeforeSuite(func() {
+func GinkgoTest(reqConfig *Config) {
+	sc := &SanityContext{
+		Config: reqConfig,
+	}
+
+	registerTestsInGinkgo(sc)
+}
+
+func (sc *SanityContext) setup() {
 	var err error
 
-	if len(config.SecretsFile) > 0 {
-		secrets, err = loadSecrets(config.SecretsFile)
+	if len(sc.Config.SecretsFile) > 0 {
+		sc.Secrets, err = loadSecrets(sc.Config.SecretsFile)
 		Expect(err).NotTo(HaveOccurred())
 	}
 
 	By("connecting to CSI driver")
-	conn, err = utils.Connect(config.Address)
+	sc.Conn, err = utils.Connect(sc.Config.Address)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("creating mount and staging directories")
-	err = createMountTargetLocation(config.TargetPath)
+	err = createMountTargetLocation(sc.Config.TargetPath)
 	Expect(err).NotTo(HaveOccurred())
-	if len(config.StagingPath) > 0 {
-		err = createMountTargetLocation(config.StagingPath)
+	if len(sc.Config.StagingPath) > 0 {
+		err = createMountTargetLocation(sc.Config.StagingPath)
 		Expect(err).NotTo(HaveOccurred())
 	}
-})
+}
 
-var _ = AfterSuite(func() {
-	conn.Close()
-})
+func (sc *SanityContext) teardown() {
+	if sc.Conn != nil {
+		sc.Conn.Close()
+		sc.Conn = nil
+	}
+}
 
 func createMountTargetLocation(targetPath string) error {
 	fileInfo, err := os.Stat(targetPath)

--- a/pkg/sanity/tests.go
+++ b/pkg/sanity/tests.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2018 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sanity
+
+import (
+	. "github.com/onsi/ginkgo"
+)
+
+type test struct {
+	text string
+	body func(*SanityContext)
+}
+
+var tests []test
+
+// DescribeSanity must be used instead of the usual Ginkgo Describe to
+// register a test block. The difference is that the body function
+// will be called multiple times with the right context (when
+// setting up a Ginkgo suite or a testing.T test, with the right
+// configuration).
+func DescribeSanity(text string, body func(*SanityContext)) bool {
+	tests = append(tests, test{text, body})
+	return true
+}
+
+// registerTestsInGinkgo invokes the actual Gingko Describe
+// for the tests registered earlier with DescribeSanity.
+func registerTestsInGinkgo(sc *SanityContext) {
+	for _, test := range tests {
+		Describe(test.text, func() {
+
+			BeforeEach(func() {
+				sc.setup()
+			})
+
+			AfterEach(func() {
+				sc.teardown()
+			})
+
+			test.body(sc)
+		})
+	}
+}


### PR DESCRIPTION
This was not possible before:
- Ginkgo only supports one set of Before/AfterSuite calls,
  which might be in use already in the existing suite (for
  example, the Kubernetes e2e framework).
- When nesting the sanity test inside a Ginkgo spec there
  is no testing.T pointer that could be passed to
  the Test method.

Now all global variables are replaced with a test context that gets
passed into the specs explicitly. For this to work, specs must be set
up with SanityDescribe instead of the previous Describe call.

The Test and Config API are unchanged, but there is one slight change
of behavior: previously it was possible to define two tests with
different configs in the same test binary and then running each test
would execute the sanity tests for that config. That no longer works
because running one test changes the global Ginkgo suite and running
the second test would then also run the specs from the first one.

This usage could be supported by having one test function which takes
multiple configs, then runs one suite that contains tests for all of
them.

Probably it is easier to just use a Ginkgo suite, because there
multiple different configs can be handled already normally via
different Describe specs: calling the new GinkgoTest API will add all
sanity test cases for one configuration to the spec in which the API
is called.