### PR TITLE
pkg/sanity: Use a single grpc connection

### DIFF
--- a/cmd/csi-sanity/Makefile
+++ b/cmd/csi-sanity/Makefile
@@ -1,5 +1,5 @@
 APP_NAME := csi-sanity
-VER :=$(shell git describe)
+VER :=$(shell git describe --tag --dirty)
 RELEASEVER := $(shell git describe --abbrev=0)
 BRANCH := $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
 SHA := $(shell git rev-parse --short HEAD)

--- a/hack/_apitest/api_test.go
+++ b/hack/_apitest/api_test.go
@@ -1,0 +1,18 @@
+package apitest
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kubernetes-csi/csi-test/pkg/sanity"
+)
+
+func TestMyDriver(t *testing.T) {
+	config := &sanity.Config{
+		TargetPath:  os.TempDir() + "/csi",
+		StagingPath: os.TempDir() + "/csi",
+		Address:     "/tmp/e2e-csi-sanity.sock",
+	}
+
+	sanity.Test(t, config)
+}

--- a/hack/_embedded/embedded_test.go
+++ b/hack/_embedded/embedded_test.go
@@ -1,0 +1,33 @@
+package embedded
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kubernetes-csi/csi-test/pkg/sanity"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMyDriverGinkgo(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CSI Sanity Test Suite")
+}
+
+var _ = Describe("MyCSIDriver", func() {
+	Context("Config A", func() {
+		config := &sanity.Config{
+			TargetPath:  os.TempDir() + "/csi",
+			StagingPath: os.TempDir() + "/csi",
+			Address:     "/tmp/e2e-csi-sanity.sock",
+		}
+
+		BeforeEach(func() {})
+
+		AfterEach(func() {})
+
+		Describe("CSI Driver Test Suite", func() {
+			sanity.GinkgoTest(config)
+		})
+	})
+})

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -35,6 +35,25 @@ runTestWithCreds()
 	fi
 }
 
+runTestAPI()
+{
+	CSI_ENDPOINT=$1 ./bin/mock &
+	local pid=$!
+
+	GOCACHE=off go test -v ./hack/_apitest/api_test.go; ret=$?
+
+	if [ $ret -ne 0 ] ; then
+		exit $ret
+	fi
+
+	GOCACHE=off go test -v ./hack/_embedded/embedded_test.go; ret=$?
+	kill -9 $pid
+
+	if [ $ret -ne 0 ] ; then
+		exit $ret
+	fi
+}
+
 go build -o bin/mock ./mock || exit 1
 
 cd cmd/csi-sanity
@@ -45,6 +64,9 @@ runTest "${UDS}" "${UDS}"
 rm -f $UDS
 
 runTestWithCreds "${UDS}" "${UDS}"
+rm -f $UDS
+
+runTestAPI "${UDS}"
 rm -f $UDS
 
 exit 0

--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -25,9 +25,10 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi/v0"
 
+	"strconv"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"strconv"
 )
 
 const (
@@ -86,8 +87,8 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 	)
 
 	BeforeEach(func() {
-		c = csi.NewControllerClient(sc.Conn)
-		n = csi.NewNodeClient(sc.Conn)
+		c = csi.NewControllerClient(conn)
+		n = csi.NewNodeClient(conn)
 
 		cl = &Cleanup{
 			NodeClient:       n,
@@ -1098,7 +1099,7 @@ var _ = DescribeSanity("ListSnapshots [Controller Server]", func(sc *SanityConte
 	)
 
 	BeforeEach(func() {
-		c = csi.NewControllerClient(sc.Conn)
+		c = csi.NewControllerClient(conn)
 
 		if !isControllerCapabilitySupported(c, csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS) {
 			Skip("ListSnapshots not supported")
@@ -1392,7 +1393,7 @@ var _ = DescribeSanity("DeleteSnapshot [Controller Server]", func(sc *SanityCont
 	)
 
 	BeforeEach(func() {
-		c = csi.NewControllerClient(sc.Conn)
+		c = csi.NewControllerClient(conn)
 
 		if !isControllerCapabilitySupported(c, csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT) {
 			Skip("DeleteSnapshot not supported")
@@ -1455,7 +1456,7 @@ var _ = DescribeSanity("CreateSnapshot [Controller Server]", func(sc *SanityCont
 	)
 
 	BeforeEach(func() {
-		c = csi.NewControllerClient(sc.Conn)
+		c = csi.NewControllerClient(conn)
 
 		if !isControllerCapabilitySupported(c, csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT) {
 			Skip("CreateSnapshot not supported")

--- a/pkg/sanity/identity.go
+++ b/pkg/sanity/identity.go
@@ -36,7 +36,7 @@ var _ = DescribeSanity("Identity Service", func(sc *SanityContext) {
 	)
 
 	BeforeEach(func() {
-		c = csi.NewIdentityClient(sc.Conn)
+		c = csi.NewIdentityClient(conn)
 	})
 
 	Describe("GetPluginCapabilities", func() {

--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -79,8 +79,8 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 	)
 
 	BeforeEach(func() {
-		c = csi.NewNodeClient(sc.Conn)
-		s = csi.NewControllerClient(sc.Conn)
+		c = csi.NewNodeClient(conn)
+		s = csi.NewControllerClient(conn)
 
 		controllerPublishSupported = isControllerCapabilitySupported(
 			s,
@@ -145,7 +145,7 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 		)
 
 		BeforeEach(func() {
-			i = csi.NewIdentityClient(sc.Conn)
+			i = csi.NewIdentityClient(conn)
 			accessibilityConstraintSupported = isPluginCapabilitySupported(i, csi.PluginCapability_Service_ACCESSIBILITY_CONSTRAINTS)
 		})
 

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -95,6 +95,7 @@ func GinkgoTest(reqConfig *Config) {
 		Config: reqConfig,
 	}
 
+	address = sc.Config.Address
 	registerTestsInGinkgo(sc)
 }
 


### PR DESCRIPTION
This change makes the grpc client connection to be stored as a global
variable and used across all the test cases. This helps avoid creating
multiple connections at every setup and teardown cycle. The whole test
suite runs faster and more reliable with a single shared connection.

Alternate solution to #97 