### PR TITLE
pkg/sanity: Use a single grpc connection via caching in SanityContext

### DIFF
--- a/hack/_apitest/api_test.go
+++ b/hack/_apitest/api_test.go
@@ -1,0 +1,18 @@
+package apitest
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kubernetes-csi/csi-test/pkg/sanity"
+)
+
+func TestMyDriver(t *testing.T) {
+	config := &sanity.Config{
+		TargetPath:  os.TempDir() + "/csi",
+		StagingPath: os.TempDir() + "/csi",
+		Address:     "/tmp/e2e-csi-sanity.sock",
+	}
+
+	sanity.Test(t, config)
+}

--- a/hack/_embedded/embedded_test.go
+++ b/hack/_embedded/embedded_test.go
@@ -14,6 +14,15 @@ func TestMyDriverGinkgo(t *testing.T) {
 	RunSpecs(t, "CSI Sanity Test Suite")
 }
 
+// The test suite into which the sanity tests get embedded may already
+// have before/after suite functions. There can only be one such
+// function. Here we define empty ones because then Ginkgo
+// will start complaining at runtime when invoking the embedded case
+// in hack/e2e.sh if a PR adds back such functions in the sanity test
+// code.
+var _ = BeforeSuite(func() {})
+var _ = AfterSuite(func() {})
+
 var _ = Describe("MyCSIDriver", func() {
 	Context("Config A", func() {
 		config := &sanity.Config{

--- a/hack/_embedded/embedded_test.go
+++ b/hack/_embedded/embedded_test.go
@@ -1,0 +1,33 @@
+package embedded
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kubernetes-csi/csi-test/pkg/sanity"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMyDriverGinkgo(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CSI Sanity Test Suite")
+}
+
+var _ = Describe("MyCSIDriver", func() {
+	Context("Config A", func() {
+		config := &sanity.Config{
+			TargetPath:  os.TempDir() + "/csi",
+			StagingPath: os.TempDir() + "/csi",
+			Address:     "/tmp/e2e-csi-sanity.sock",
+		}
+
+		BeforeEach(func() {})
+
+		AfterEach(func() {})
+
+		Describe("CSI Driver Test Suite", func() {
+			sanity.GinkgoTest(config)
+		})
+	})
+})

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -35,6 +35,25 @@ runTestWithCreds()
 	fi
 }
 
+runTestAPI()
+{
+	CSI_ENDPOINT=$1 ./bin/mock &
+	local pid=$!
+
+	GOCACHE=off go test -v ./hack/_apitest/api_test.go; ret=$?
+
+	if [ $ret -ne 0 ] ; then
+		exit $ret
+	fi
+
+	GOCACHE=off go test -v ./hack/_embedded/embedded_test.go; ret=$?
+	kill -9 $pid
+
+	if [ $ret -ne 0 ] ; then
+		exit $ret
+	fi
+}
+
 go build -o bin/mock ./mock || exit 1
 
 cd cmd/csi-sanity
@@ -45,6 +64,9 @@ runTest "${UDS}" "${UDS}"
 rm -f $UDS
 
 runTestWithCreds "${UDS}" "${UDS}"
+rm -f $UDS
+
+runTestAPI "${UDS}"
 rm -f $UDS
 
 exit 0


### PR DESCRIPTION
This uses the same approach as PR #98 to combat connection issues (connecting only once per process), but implements it so that the tests can still be embedded, by caching the existing connection in the SanityContext.

@darkowlzz I liked the API tests that you added to PR #98, so I've copied your commit into this PR and extended the one about embedding so that it actually catches when the tests (incorrectly) try to use their own Before/AfterSuite functions.

