### PR TITLE
Remove bad assertion in ListSnapshots test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 *.out
 bin/mock
 cmd/csi-sanity/csi-sanity
+
+# JetBrains GoLand
+.idea

--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -1349,7 +1349,6 @@ var _ = DescribeSanity("ListSnapshots [Controller Server]", func(sc *SanityConte
 
 		nextToken := snapshots.GetNextToken()
 
-		Expect(nextToken).To(Equal(strconv.Itoa(maxEntries)))
 		Expect(len(snapshots.GetEntries())).To(Equal(maxEntries))
 
 		// Request list snapshots with starting_token and no max entries.


### PR DESCRIPTION
The CSI spec doesn't require that NextToken is an integer, it should
be treated as an opaque string, therefore remove an assertion that
assumes it is an integer.

Fixes #104