### PR TITLE
Add tests for long names

### DIFF
--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -35,6 +35,8 @@ const (
 	// provisioned volumes. 10GB by default, can be overridden by
 	// setting Config.TestVolumeSize.
 	DefTestVolumeSize int64 = 10 * 1024 * 1024 * 1024
+
+	MaxNameLength int = 128
 )
 
 func TestVolumeSize(sc *SanityContext) int64 {
@@ -437,6 +439,56 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 				context.Background(),
 				&csi.DeleteVolumeRequest{
 					VolumeId:                vol1.GetVolume().GetId(),
+					ControllerDeleteSecrets: sc.Secrets.DeleteVolumeSecret,
+				},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			cl.UnregisterVolume(name)
+		})
+
+		It("should not fail when creating volume with maximum-length name", func() {
+
+			nameBytes := make([]byte, MaxNameLength)
+			for i := 0; i < MaxNameLength; i++ {
+				nameBytes[i] = 'a'
+			}
+			name := string(nameBytes)
+			By("creating a volume")
+			size := TestVolumeSize(sc)
+
+			vol, err := c.CreateVolume(
+				context.Background(),
+				&csi.CreateVolumeRequest{
+					Name: name,
+					VolumeCapabilities: []*csi.VolumeCapability{
+						{
+							AccessType: &csi.VolumeCapability_Mount{
+								Mount: &csi.VolumeCapability_MountVolume{},
+							},
+							AccessMode: &csi.VolumeCapability_AccessMode{
+								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+							},
+						},
+					},
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: size,
+					},
+					ControllerCreateSecrets: sc.Secrets.CreateVolumeSecret,
+				},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vol).NotTo(BeNil())
+			Expect(vol.GetVolume()).NotTo(BeNil())
+			Expect(vol.GetVolume().GetId()).NotTo(BeEmpty())
+			cl.RegisterVolume(name, VolumeInfo{VolumeID: vol.GetVolume().GetId()})
+			Expect(vol.GetVolume().GetCapacityBytes()).To(BeNumerically(">=", size))
+
+			By("cleaning up deleting the volume")
+
+			_, err = c.DeleteVolume(
+				context.Background(),
+				&csi.DeleteVolumeRequest{
+					VolumeId:                vol.GetVolume().GetId(),
 					ControllerDeleteSecrets: sc.Secrets.DeleteVolumeSecret,
 				},
 			)
@@ -1546,6 +1598,42 @@ var _ = DescribeSanity("CreateSnapshot [Controller Server]", func(sc *SanityCont
 		serverError, ok := status.FromError(err)
 		Expect(ok).To(BeTrue())
 		Expect(serverError.Code()).To(Equal(codes.AlreadyExists))
+
+		By("cleaning up deleting the snapshot")
+		delSnapReq := MakeDeleteSnapshotReq(sc, snap1.GetSnapshot().GetId())
+		_, err = c.DeleteSnapshot(context.Background(), delSnapReq)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("cleaning up deleting the volume")
+		delVolReq := MakeDeleteVolumeReq(sc, volume.GetVolume().GetId())
+		_, err = c.DeleteVolume(context.Background(), delVolReq)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should not fail when creating snapshot with maximum-length name", func() {
+
+		By("creating a volume")
+		volReq := MakeCreateVolumeReq(sc, "CreateSnapshot-volume-3")
+		volume, err := c.CreateVolume(context.Background(), volReq)
+		Expect(err).NotTo(HaveOccurred())
+
+		nameBytes := make([]byte, MaxNameLength)
+		for i := 0; i < MaxNameLength; i++ {
+			nameBytes[i] = 'a'
+		}
+		name := string(nameBytes)
+
+		By("creating a snapshot")
+		snapReq1 := MakeCreateSnapshotReq(sc, name, volume.GetVolume().GetId(), nil)
+		snap1, err := c.CreateSnapshot(context.Background(), snapReq1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(snap1).NotTo(BeNil())
+		verifySnapshotInfo(snap1.GetSnapshot())
+
+		snap2, err := c.CreateSnapshot(context.Background(), snapReq1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(snap2).NotTo(BeNil())
+		verifySnapshotInfo(snap2.GetSnapshot())
 
 		By("cleaning up deleting the snapshot")
 		delSnapReq := MakeDeleteSnapshotReq(sc, snap1.GetSnapshot().GetId())


### PR DESCRIPTION
Create 2 new tests, one for a volume with a maximum-length name,
and one for a snapshot with maximum-length name. These tests are
intended to catch bugs where plugin authors use the value of the
name field in a context where 128 characters exceeds a limit in
some other system.

Fixes #107 