### PR TITLE
Update mock driver for testing

### DIFF
--- a/mock/main.go
+++ b/mock/main.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"fmt"
 	"net"
 	"os"
@@ -28,6 +29,11 @@ import (
 )
 
 func main() {
+	var config service.Config
+	flag.BoolVar(&config.DisableAttach, "disable-attach", false, "Disables RPC_PUBLISH_UNPUBLISH_VOLUME capability.")
+	flag.StringVar(&config.DriverName, "name", service.Name, "CSI driver name.")
+	flag.Parse()
+
 	endpoint := os.Getenv("CSI_ENDPOINT")
 	if len(endpoint) == 0 {
 		fmt.Println("CSI_ENDPOINT must be defined and must be a path")
@@ -39,7 +45,7 @@ func main() {
 	}
 
 	// Create mock driver
-	s := service.New()
+	s := service.New(config)
 	servers := &driver.CSIDriverServers{
 		Controller: s,
 		Identity:   s,

--- a/mock/service/identity.go
+++ b/mock/service/identity.go
@@ -13,7 +13,7 @@ func (s *service) GetPluginInfo(
 	*csi.GetPluginInfoResponse, error) {
 
 	return &csi.GetPluginInfoResponse{
-		Name:          Name,
+		Name:          s.config.DriverName,
 		VendorVersion: VendorVersion,
 		Manifest:      Manifest,
 	}, nil

--- a/mock/service/node.go
+++ b/mock/service/node.go
@@ -18,9 +18,13 @@ func (s *service) NodeStageVolume(
 
 	device, ok := req.PublishInfo["device"]
 	if !ok {
-		return nil, status.Error(
-			codes.InvalidArgument,
-			"stage volume info 'device' key required")
+		if s.config.DisableAttach {
+			device = "mock device"
+		} else {
+			return nil, status.Error(
+				codes.InvalidArgument,
+				"stage volume info 'device' key required")
+		}
 	}
 
 	if len(req.GetVolumeId()) == 0 {
@@ -105,9 +109,13 @@ func (s *service) NodePublishVolume(
 
 	device, ok := req.PublishInfo["device"]
 	if !ok {
-		return nil, status.Error(
-			codes.InvalidArgument,
-			"publish volume info 'device' key required")
+		if s.config.DisableAttach {
+			device = "mock device"
+		} else {
+			return nil, status.Error(
+				codes.InvalidArgument,
+				"stage volume info 'device' key required")
+		}
 	}
 
 	if len(req.GetVolumeId()) == 0 {

--- a/mock/service/service.go
+++ b/mock/service/service.go
@@ -25,6 +25,11 @@ var Manifest = map[string]string{
 	"url": "https://github.com/kubernetes-csi/csi-test/mock",
 }
 
+type Config struct {
+	DisableAttach bool
+	DriverName    string
+}
+
 // Service is the CSI Mock service provider.
 type Service interface {
 	csi.ControllerServer
@@ -40,6 +45,7 @@ type service struct {
 	volsNID      uint64
 	snapshots    cache.SnapshotCache
 	snapshotsNID uint64
+	config       Config
 }
 
 type Volume struct {
@@ -55,8 +61,11 @@ type Volume struct {
 var MockVolumes map[string]Volume
 
 // New returns a new Service.
-func New() Service {
-	s := &service{nodeID: Name}
+func New(config Config) Service {
+	s := &service{
+		nodeID: config.DriverName,
+		config: config,
+	}
 	s.snapshots = cache.NewSnapshotCache()
 	s.vols = []csi.Volume{
 		s.newVolume("Mock Volume 1", gib100),


### PR DESCRIPTION
For CO (Kubernetes) e2e test we need a driver that:

1. Can optionally skip attach.
2. Has configurable driver name (so we can run multiple drivers + multiple tests in parallel).
3. Log all CSI calls (as json) so a test can check that the CO sent the right calls.