### PR TITLE
Add volume parameters to sanity tests

### DIFF
--- a/cmd/csi-sanity/sanity_test.go
+++ b/cmd/csi-sanity/sanity_test.go
@@ -41,6 +41,7 @@ func init() {
 	flag.StringVar(&config.StagingPath, prefix+"stagingdir", os.TempDir()+"/csi", "Mount point for NodeStage if staging is supported")
 	flag.StringVar(&config.SecretsFile, prefix+"secrets", "", "CSI secrets file")
 	flag.Int64Var(&config.TestVolumeSize, prefix+"testvolumesize", sanity.DefTestVolumeSize, "Base volume size used for provisioned volumes")
+	flag.StringVar(&config.TestVolumeParametersFile, prefix+"testvolumeparameters", "", "YAML file of volume parameters for provisioned volumes")
 	flag.Parse()
 }
 

--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -185,6 +185,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 				context.Background(),
 				&csi.CreateVolumeRequest{
 					ControllerCreateSecrets: sc.Secrets.CreateVolumeSecret,
+					Parameters:              sc.Config.TestVolumeParameters,
 				},
 			)
 			cl.MaybeRegisterVolume("", vol, err)
@@ -202,6 +203,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 				&csi.CreateVolumeRequest{
 					Name: name,
 					ControllerCreateSecrets: sc.Secrets.CreateVolumeSecret,
+					Parameters:              sc.Config.TestVolumeParameters,
 				},
 			)
 			cl.MaybeRegisterVolume(name, vol, err)
@@ -232,6 +234,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 						},
 					},
 					ControllerCreateSecrets: sc.Secrets.CreateVolumeSecret,
+					Parameters:              sc.Config.TestVolumeParameters,
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -276,6 +279,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 						RequiredBytes: TestVolumeSize(sc),
 					},
 					ControllerCreateSecrets: sc.Secrets.CreateVolumeSecret,
+					Parameters:              sc.Config.TestVolumeParameters,
 				},
 			)
 			if serverError, ok := status.FromError(err); ok &&
@@ -325,6 +329,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 						RequiredBytes: size,
 					},
 					ControllerCreateSecrets: sc.Secrets.CreateVolumeSecret,
+					Parameters:              sc.Config.TestVolumeParameters,
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -352,6 +357,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 						RequiredBytes: size,
 					},
 					ControllerCreateSecrets: sc.Secrets.CreateVolumeSecret,
+					Parameters:              sc.Config.TestVolumeParameters,
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -398,6 +404,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 						LimitBytes:    size1,
 					},
 					ControllerCreateSecrets: sc.Secrets.CreateVolumeSecret,
+					Parameters:              sc.Config.TestVolumeParameters,
 				},
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -426,6 +433,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 						LimitBytes:    size2,
 					},
 					ControllerCreateSecrets: sc.Secrets.CreateVolumeSecret,
+					Parameters:              sc.Config.TestVolumeParameters,
 				},
 			)
 			Expect(err).To(HaveOccurred())
@@ -474,6 +482,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 						RequiredBytes: size,
 					},
 					ControllerCreateSecrets: sc.Secrets.CreateVolumeSecret,
+					Parameters:              sc.Config.TestVolumeParameters,
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -552,6 +561,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 						},
 					},
 					ControllerCreateSecrets: sc.Secrets.CreateVolumeSecret,
+					Parameters:              sc.Config.TestVolumeParameters,
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -623,6 +633,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 						},
 					},
 					ControllerCreateSecrets: sc.Secrets.CreateVolumeSecret,
+					Parameters:              sc.Config.TestVolumeParameters,
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -767,6 +778,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 						},
 					},
 					ControllerCreateSecrets: sc.Secrets.CreateVolumeSecret,
+					Parameters:              sc.Config.TestVolumeParameters,
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -884,6 +896,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 						},
 					},
 					ControllerCreateSecrets: sc.Secrets.CreateVolumeSecret,
+					Parameters:              sc.Config.TestVolumeParameters,
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -953,6 +966,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 						},
 					},
 					ControllerCreateSecrets: sc.Secrets.CreateVolumeSecret,
+					Parameters:              sc.Config.TestVolumeParameters,
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -1074,6 +1088,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 						},
 					},
 					ControllerCreateSecrets: sc.Secrets.CreateVolumeSecret,
+					Parameters:              sc.Config.TestVolumeParameters,
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -1628,6 +1643,7 @@ func MakeCreateVolumeReq(sc *SanityContext, name string) *csi.CreateVolumeReques
 			RequiredBytes: size1,
 			LimitBytes:    size1,
 		},
+		Parameters: sc.Config.TestVolumeParameters,
 	}
 
 	if sc.Secrets != nil {

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -47,11 +47,14 @@ type CSISecrets struct {
 // Config provides the configuration for the sanity tests. It
 // needs to be initialized by the user of the sanity package.
 type Config struct {
-	TargetPath     string
-	StagingPath    string
-	Address        string
-	SecretsFile    string
-	TestVolumeSize int64
+	TargetPath  string
+	StagingPath string
+	Address     string
+	SecretsFile string
+
+	TestVolumeSize           int64
+	TestVolumeParametersFile string
+	TestVolumeParameters     map[string]string
 }
 
 // SanityContext holds the variables that each test can depend on. It
@@ -67,6 +70,18 @@ type SanityContext struct {
 // Test will test the CSI driver at the specified address by
 // setting up a Ginkgo suite and running it.
 func Test(t *testing.T, reqConfig *Config) {
+	path := reqConfig.TestVolumeParametersFile
+	if len(path) != 0 {
+		yamlFile, err := ioutil.ReadFile(path)
+		if err != nil {
+			panic(fmt.Sprintf("failed to read file %q: %v", path, err))
+		}
+		err = yaml.Unmarshal(yamlFile, &reqConfig.TestVolumeParameters)
+		if err != nil {
+			panic(fmt.Sprintf("error unmarshaling yaml: %v", err))
+		}
+	}
+
 	sc := &SanityContext{
 		Config: reqConfig,
 	}


### PR DESCRIPTION
This is a relatively naive attempt to implement some functionality I'd like to have for my CSI driver development, namely the ability to specify `VolumeParameters` for my test volumes.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>