### PR TITLE
Use binary complied by make for e2e tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ matrix:
   - go: 1.10.3
 script:
 - make test
-- make
 after_success:
   - if [ "${TRAVIS_BRANCH}" == "master" ] && [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
       make container

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ container: $(APP)
 push: container
 	docker push $(IMAGE_NAME):$(IMAGE_VERSION)
 
-test:
+test: $(APP)
 	files=$$(find ./ -name '*.go' | grep -v '^./vendor' ); \
         if [ $$(gofmt -d $$files | wc -l) -ne 0 ]; then \
                 echo "formatting errors:"; \

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -54,7 +54,7 @@ runTestAPI()
 	fi
 }
 
-go build -o bin/mock ./mock || exit 1
+test -x bin/mock || exit 1
 
 cd cmd/csi-sanity
   make clean install || exit 1


### PR DESCRIPTION
`hack/e2e.sh` should use the "official" binary created by make instead of its own build

1. we should test the real binary
2. `make test; make; make container` (as our travis does) should use the real binary instead of the wrong one built by `make test`

@pohly @lpabon, PTAL