### PR TITLE
Add support for attach limits to the mock driver

### DIFF
--- a/mock/main.go
+++ b/mock/main.go
@@ -32,6 +32,7 @@ func main() {
 	var config service.Config
 	flag.BoolVar(&config.DisableAttach, "disable-attach", false, "Disables RPC_PUBLISH_UNPUBLISH_VOLUME capability.")
 	flag.StringVar(&config.DriverName, "name", service.Name, "CSI driver name.")
+	flag.Int64Var(&config.AttachLimit, "attach-limit", 0, "number of attachable volumes on a node")
 	flag.Parse()
 
 	endpoint := os.Getenv("CSI_ENDPOINT")

--- a/mock/service/node.go
+++ b/mock/service/node.go
@@ -238,9 +238,13 @@ func (s *service) NodeGetCapabilities(
 
 func (s *service) NodeGetInfo(ctx context.Context,
 	req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
-	return &csi.NodeGetInfoResponse{
+	csiNodeResponse := &csi.NodeGetInfoResponse{
 		NodeId: s.nodeID,
-	}, nil
+	}
+	if s.config.AttachLimit > 0 {
+		csiNodeResponse.MaxVolumesPerNode = s.config.AttachLimit
+	}
+	return csiNodeResponse, nil
 }
 
 func (s *service) NodeGetVolumeStats(ctx context.Context,

--- a/mock/service/service.go
+++ b/mock/service/service.go
@@ -28,6 +28,7 @@ var Manifest = map[string]string{
 type Config struct {
 	DisableAttach bool
 	DriverName    string
+	AttachLimit   int64
 }
 
 // Service is the CSI Mock service provider.


### PR DESCRIPTION
Allow configurable attach limit.