### PR TITLE
Add driver roles to sanity tests

### DIFF
--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -32,6 +32,24 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// Valid CSI driver roles, used for parsing tests
+type DriverRole string
+type DriverRoles []DriverRole
+
+func (drs DriverRoles) String() []string {
+	strs := []string{}
+	for _, d := range drs {
+		strs = append(strs, string(d))
+	}
+	return strs
+}
+
+const (
+	DriverRoleIdentity   DriverRole = "Identity"
+	DriverRoleController DriverRole = "Controller"
+	DriverRoleNode       DriverRole = "Node"
+)
+
 // CSISecrets consists of secrets used in CSI credentials.
 type CSISecrets struct {
 	CreateVolumeSecret              map[string]string `yaml:"CreateVolumeSecret"`
@@ -51,6 +69,8 @@ type Config struct {
 	StagingPath string
 	Address     string
 	SecretsFile string
+
+	Roles DriverRoles
 
 	TestVolumeSize           int64
 	TestVolumeParametersFile string

--- a/pkg/sanity/tests.go
+++ b/pkg/sanity/tests.go
@@ -17,6 +17,10 @@ limitations under the License.
 package sanity
 
 import (
+	"fmt"
+	"regexp"
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 )
 
@@ -40,17 +44,20 @@ func DescribeSanity(text string, body func(*SanityContext)) bool {
 // registerTestsInGinkgo invokes the actual Gingko Describe
 // for the tests registered earlier with DescribeSanity.
 func registerTestsInGinkgo(sc *SanityContext) {
+	roleMatch := regexp.MustCompile(fmt.Sprintf(".*(?:%s).*", strings.Join(sc.Config.Roles.String(), "|")))
 	for _, test := range tests {
-		Describe(test.text, func() {
-			BeforeEach(func() {
-				sc.setup()
-			})
+		if roleMatch.MatchString(test.text) {
+			Describe(test.text, func() {
+				BeforeEach(func() {
+					sc.setup()
+				})
 
-			test.body(sc)
+				test.body(sc)
 
-			AfterEach(func() {
-				sc.teardown()
+				AfterEach(func() {
+					sc.teardown()
+				})
 			})
-		})
+		}
 	}
 }


### PR DESCRIPTION
This patch adds the ability to specify driver roles (Identity,
Controller, Node) for a given test run. This allows for a convenient,
code-based mechanism to parse which sanity tests will be run for a given
driver. This then allows for simpler "go test" CLI calls that helps
facilitate development and automation complexity.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>