### PR TITLE
Use NodeGetInfo to get node Id

### DIFF
--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -787,10 +787,10 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 			Expect(vol.GetVolume().GetId()).NotTo(BeEmpty())
 			cl.RegisterVolume(name, VolumeInfo{VolumeID: vol.GetVolume().GetId()})
 
-			By("getting a node id")
-			nid, err := n.NodeGetId(
+			By("getting a node info")
+			nid, err := n.NodeGetInfo(
 				context.Background(),
-				&csi.NodeGetIdRequest{})
+				&csi.NodeGetInfoRequest{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nid).NotTo(BeNil())
 			Expect(nid.GetNodeId()).NotTo(BeEmpty())
@@ -975,10 +975,10 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 			Expect(vol.GetVolume().GetId()).NotTo(BeEmpty())
 			cl.RegisterVolume(name, VolumeInfo{VolumeID: vol.GetVolume().GetId()})
 
-			By("getting a node id")
-			nid, err := n.NodeGetId(
+			By("getting a node info")
+			nid, err := n.NodeGetInfo(
 				context.Background(),
-				&csi.NodeGetIdRequest{})
+				&csi.NodeGetInfoRequest{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nid).NotTo(BeNil())
 			Expect(nid.GetNodeId()).NotTo(BeEmpty())
@@ -1097,10 +1097,10 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 			Expect(vol.GetVolume().GetId()).NotTo(BeEmpty())
 			cl.RegisterVolume(name, VolumeInfo{VolumeID: vol.GetVolume().GetId()})
 
-			By("getting a node id")
-			nid, err := n.NodeGetId(
+			By("getting a node info")
+			nid, err := n.NodeGetInfo(
 				context.Background(),
-				&csi.NodeGetIdRequest{})
+				&csi.NodeGetInfoRequest{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nid).NotTo(BeNil())
 			Expect(nid.GetNodeId()).NotTo(BeEmpty())

--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -390,10 +390,10 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 		Expect(vol.GetVolume().GetId()).NotTo(BeEmpty())
 		cl.RegisterVolume(name, VolumeInfo{VolumeID: vol.GetVolume().GetId()})
 
-		By("getting a node id")
-		nid, err := c.NodeGetId(
+		By("getting a node info")
+		nid, err := c.NodeGetInfo(
 			context.Background(),
-			&csi.NodeGetIdRequest{})
+			&csi.NodeGetInfoRequest{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nid).NotTo(BeNil())
 		Expect(nid.GetNodeId()).NotTo(BeEmpty())


### PR DESCRIPTION
Because NodeGetId RPC call is deprecated in CSI spec v0.3.0,
we should use NodeGetInfo to get node Id in sanity test.

In the part of [NodeGetId in CSI spec v0.3.0](https://github.com/container-storage-interface/spec/blob/v0.3.0/spec.md#nodegetid), it is found that NodeGetId has been deprecated.
```
NodeGetId RPC call is deprecated. Users of this RPC call SHOULD use NodeGetInfo.
```
