### PR TITLE
Update v0.3.0 branch to release 0.3.0-4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 *.out
 bin/mock
 cmd/csi-sanity/csi-sanity
+
+# JetBrains GoLand
+.idea

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing Guidelines
+
+Welcome to Kubernetes. We are excited about the prospect of you joining our [community](https://github.com/kubernetes/community)! The Kubernetes community abides by the CNCF [code of conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md). Here is an excerpt:
+
+_As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities._
+
+## Getting Started
+
+We have full documentation on how to get started contributing here:
+
+- [Contributor License Agreement](https://git.k8s.io/community/CLA.md) Kubernetes projects require that you sign a Contributor License Agreement (CLA) before we can accept your pull requests
+- [Kubernetes Contributor Guide](http://git.k8s.io/community/contributors/guide) - Main contributor documentation, or you can just jump directly to the [contributing section](http://git.k8s.io/community/contributors/guide#contributing)
+- [Contributor Cheat Sheet](https://git.k8s.io/community/contributors/guide/contributor-cheatsheet.md) - Common resources for existing developers
+
+## Mentorship
+
+- [Mentoring Initiatives](https://git.k8s.io/community/mentoring) - We have a diverse set of mentorship programs available that are always looking for volunteers!
+
+## Contact Information
+
+- [Slack channel](https://kubernetes.slack.com/messages/sig-storage)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-storage)

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- saad-ali
+- lpabon
+- pohly

--- a/README.md
+++ b/README.md
@@ -27,3 +27,16 @@ CSI driver.
 
 * Master is for CSI v0.3.0. Please see the branches for other CSI releases.
 * Only Golang 1.9+ supported. See [gRPC issue](https://github.com/grpc/grpc-go/issues/711#issuecomment-326626790)
+
+## Community, discussion, contribution, and support
+
+Learn how to engage with the Kubernetes community on the [community page](http://kubernetes.io/community/).
+
+You can reach the maintainers of this project at:
+
+- [Slack channel](https://kubernetes.slack.com/messages/sig-storage)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-storage)
+
+### Code of conduct
+
+Participation in the Kubernetes community is governed by the [Kubernetes Code of Conduct](code-of-conduct.md).

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -1,0 +1,14 @@
+# Defined below are the security contacts for this repo.
+#
+# They are the contact point for the Product Security Team to reach out
+# to for triaging and handling of incoming issues.
+#
+# The below names agree to abide by the
+# [Embargo Policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy)
+# and will be removed and replaced if they violate that agreement.
+#
+# DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
+# INSTRUCTIONS AT https://kubernetes.io/security/
+
+saad-ali
+lpabon

--- a/hack/_apitest/api_test.go
+++ b/hack/_apitest/api_test.go
@@ -1,0 +1,18 @@
+package apitest
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kubernetes-csi/csi-test/pkg/sanity"
+)
+
+func TestMyDriver(t *testing.T) {
+	config := &sanity.Config{
+		TargetPath:  os.TempDir() + "/csi",
+		StagingPath: os.TempDir() + "/csi",
+		Address:     "/tmp/e2e-csi-sanity.sock",
+	}
+
+	sanity.Test(t, config)
+}

--- a/hack/_embedded/embedded_test.go
+++ b/hack/_embedded/embedded_test.go
@@ -14,6 +14,15 @@ func TestMyDriverGinkgo(t *testing.T) {
 	RunSpecs(t, "CSI Sanity Test Suite")
 }
 
+// The test suite into which the sanity tests get embedded may already
+// have before/after suite functions. There can only be one such
+// function. Here we define empty ones because then Ginkgo
+// will start complaining at runtime when invoking the embedded case
+// in hack/e2e.sh if a PR adds back such functions in the sanity test
+// code.
+var _ = BeforeSuite(func() {})
+var _ = AfterSuite(func() {})
+
 var _ = Describe("MyCSIDriver", func() {
 	Context("Config A", func() {
 		config := &sanity.Config{

--- a/hack/_embedded/embedded_test.go
+++ b/hack/_embedded/embedded_test.go
@@ -1,0 +1,33 @@
+package embedded
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kubernetes-csi/csi-test/pkg/sanity"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMyDriverGinkgo(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CSI Sanity Test Suite")
+}
+
+var _ = Describe("MyCSIDriver", func() {
+	Context("Config A", func() {
+		config := &sanity.Config{
+			TargetPath:  os.TempDir() + "/csi",
+			StagingPath: os.TempDir() + "/csi",
+			Address:     "/tmp/e2e-csi-sanity.sock",
+		}
+
+		BeforeEach(func() {})
+
+		AfterEach(func() {})
+
+		Describe("CSI Driver Test Suite", func() {
+			sanity.GinkgoTest(config)
+		})
+	})
+})

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -35,6 +35,25 @@ runTestWithCreds()
 	fi
 }
 
+runTestAPI()
+{
+	CSI_ENDPOINT=$1 ./bin/mock &
+	local pid=$!
+
+	GOCACHE=off go test -v ./hack/_apitest/api_test.go; ret=$?
+
+	if [ $ret -ne 0 ] ; then
+		exit $ret
+	fi
+
+	GOCACHE=off go test -v ./hack/_embedded/embedded_test.go; ret=$?
+	kill -9 $pid
+
+	if [ $ret -ne 0 ] ; then
+		exit $ret
+	fi
+}
+
 go build -o bin/mock ./mock || exit 1
 
 cd cmd/csi-sanity
@@ -45,6 +64,9 @@ runTest "${UDS}" "${UDS}"
 rm -f $UDS
 
 runTestWithCreds "${UDS}" "${UDS}"
+rm -f $UDS
+
+runTestAPI "${UDS}"
 rm -f $UDS
 
 exit 0

--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -1349,7 +1349,6 @@ var _ = DescribeSanity("ListSnapshots [Controller Server]", func(sc *SanityConte
 
 		nextToken := snapshots.GetNextToken()
 
-		Expect(nextToken).To(Equal(strconv.Itoa(maxEntries)))
 		Expect(len(snapshots.GetEntries())).To(Equal(maxEntries))
 
 		// Request list snapshots with starting_token and no max entries.

--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -1254,46 +1254,6 @@ var _ = DescribeSanity("ListSnapshots [Controller Server]", func(sc *SanityConte
 		Expect(snapshots.GetEntries()).To(BeEmpty())
 	})
 
-	It("should fail when an invalid starting_token is passed", func() {
-		vols, err := c.ListSnapshots(
-			context.Background(),
-			&csi.ListSnapshotsRequest{
-				StartingToken: "invalid-token",
-			},
-		)
-		Expect(err).To(HaveOccurred())
-		Expect(vols).To(BeNil())
-
-		serverError, ok := status.FromError(err)
-		Expect(ok).To(BeTrue())
-		Expect(serverError.Code()).To(Equal(codes.Aborted))
-	})
-
-	It("should fail when the starting_token is greater than total number of snapshots", func() {
-		// Get total number of snapshots.
-		snapshots, err := c.ListSnapshots(
-			context.Background(),
-			&csi.ListSnapshotsRequest{})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(snapshots).NotTo(BeNil())
-
-		totalSnapshots := len(snapshots.GetEntries())
-
-		// Send starting_token that is greater than the total number of snapshots.
-		snapshots, err = c.ListSnapshots(
-			context.Background(),
-			&csi.ListSnapshotsRequest{
-				StartingToken: strconv.Itoa(totalSnapshots + 5),
-			},
-		)
-		Expect(err).To(HaveOccurred())
-		Expect(snapshots).To(BeNil())
-
-		serverError, ok := status.FromError(err)
-		Expect(ok).To(BeTrue())
-		Expect(serverError.Code()).To(Equal(codes.Aborted))
-	})
-
 	It("check the presence of new snapshots in the snapshot list", func() {
 		// List Snapshots before creating new snapshots.
 		snapshots, err := c.ListSnapshots(

--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -35,6 +35,8 @@ const (
 	// provisioned volumes. 10GB by default, can be overridden by
 	// setting Config.TestVolumeSize.
 	DefTestVolumeSize int64 = 10 * 1024 * 1024 * 1024
+
+	MaxNameLength int = 128
 )
 
 func TestVolumeSize(sc *SanityContext) int64 {
@@ -437,6 +439,56 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 				context.Background(),
 				&csi.DeleteVolumeRequest{
 					VolumeId:                vol1.GetVolume().GetId(),
+					ControllerDeleteSecrets: sc.Secrets.DeleteVolumeSecret,
+				},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			cl.UnregisterVolume(name)
+		})
+
+		It("should not fail when creating volume with maximum-length name", func() {
+
+			nameBytes := make([]byte, MaxNameLength)
+			for i := 0; i < MaxNameLength; i++ {
+				nameBytes[i] = 'a'
+			}
+			name := string(nameBytes)
+			By("creating a volume")
+			size := TestVolumeSize(sc)
+
+			vol, err := c.CreateVolume(
+				context.Background(),
+				&csi.CreateVolumeRequest{
+					Name: name,
+					VolumeCapabilities: []*csi.VolumeCapability{
+						{
+							AccessType: &csi.VolumeCapability_Mount{
+								Mount: &csi.VolumeCapability_MountVolume{},
+							},
+							AccessMode: &csi.VolumeCapability_AccessMode{
+								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+							},
+						},
+					},
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: size,
+					},
+					ControllerCreateSecrets: sc.Secrets.CreateVolumeSecret,
+				},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vol).NotTo(BeNil())
+			Expect(vol.GetVolume()).NotTo(BeNil())
+			Expect(vol.GetVolume().GetId()).NotTo(BeEmpty())
+			cl.RegisterVolume(name, VolumeInfo{VolumeID: vol.GetVolume().GetId()})
+			Expect(vol.GetVolume().GetCapacityBytes()).To(BeNumerically(">=", size))
+
+			By("cleaning up deleting the volume")
+
+			_, err = c.DeleteVolume(
+				context.Background(),
+				&csi.DeleteVolumeRequest{
+					VolumeId:                vol.GetVolume().GetId(),
 					ControllerDeleteSecrets: sc.Secrets.DeleteVolumeSecret,
 				},
 			)
@@ -1545,6 +1597,42 @@ var _ = DescribeSanity("CreateSnapshot [Controller Server]", func(sc *SanityCont
 		serverError, ok := status.FromError(err)
 		Expect(ok).To(BeTrue())
 		Expect(serverError.Code()).To(Equal(codes.AlreadyExists))
+
+		By("cleaning up deleting the snapshot")
+		delSnapReq := MakeDeleteSnapshotReq(sc, snap1.GetSnapshot().GetId())
+		_, err = c.DeleteSnapshot(context.Background(), delSnapReq)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("cleaning up deleting the volume")
+		delVolReq := MakeDeleteVolumeReq(sc, volume.GetVolume().GetId())
+		_, err = c.DeleteVolume(context.Background(), delVolReq)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should not fail when creating snapshot with maximum-length name", func() {
+
+		By("creating a volume")
+		volReq := MakeCreateVolumeReq(sc, "CreateSnapshot-volume-3")
+		volume, err := c.CreateVolume(context.Background(), volReq)
+		Expect(err).NotTo(HaveOccurred())
+
+		nameBytes := make([]byte, MaxNameLength)
+		for i := 0; i < MaxNameLength; i++ {
+			nameBytes[i] = 'a'
+		}
+		name := string(nameBytes)
+
+		By("creating a snapshot")
+		snapReq1 := MakeCreateSnapshotReq(sc, name, volume.GetVolume().GetId(), nil)
+		snap1, err := c.CreateSnapshot(context.Background(), snapReq1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(snap1).NotTo(BeNil())
+		verifySnapshotInfo(snap1.GetSnapshot())
+
+		snap2, err := c.CreateSnapshot(context.Background(), snapReq1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(snap2).NotTo(BeNil())
+		verifySnapshotInfo(snap2.GetSnapshot())
 
 		By("cleaning up deleting the snapshot")
 		delSnapReq := MakeDeleteSnapshotReq(sc, snap1.GetSnapshot().GetId())


### PR DESCRIPTION
By mistake, I had released 0.3.0-3 from master which used the latest CSI spec instead of 0.3.0. This PR is created to cherry-pick all the changes from master to the v0.3.0 branch up to the version which changed the CSI spec in the vendor dir.
