### PR TITLE
Fix controller publish in readonly mode

### DIFF
--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -953,6 +953,9 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 		})
 
 		It("should fail when the volume is already published but is incompatible", func() {
+			if !isControllerCapabilitySupported(c, csi.ControllerServiceCapability_RPC_PUBLISH_READONLY) {
+				Skip("ControllerPublishVolume.readonly field not supported")
+			}
 
 			// Create Volume First
 			By("creating a single node writer volume")


### PR DESCRIPTION
Plugin's PUBLISH_READONLY capability should be verified
before publishing volume in readonly mode.