### PR TITLE
sanity: close connection

### DIFF
--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -89,6 +89,7 @@ func Test(t *testing.T, reqConfig *Config) {
 	registerTestsInGinkgo(sc)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CSI Driver Test Suite")
+	sc.Conn.Close()
 }
 
 func GinkgoTest(reqConfig *Config) {


### PR DESCRIPTION
Close the gRPC connection properly at the end of the test to avoid any
transport error in the subsequent connections.