### PR TITLE
mock: add PUBLISH_READONLY capability to driver

### DIFF
--- a/mock/service/controller.go
+++ b/mock/service/controller.go
@@ -386,6 +386,13 @@ func (s *service) ControllerGetCapabilities(
 				},
 			},
 		},
+		{
+			Type: &csi.ControllerServiceCapability_Rpc{
+				Rpc: &csi.ControllerServiceCapability_RPC{
+					Type: csi.ControllerServiceCapability_RPC_PUBLISH_READONLY,
+				},
+			},
+		},
 	}
 
 	if !s.config.DisableAttach {


### PR DESCRIPTION
The mock driver already supports publishing readonly volume capability,
but since readonly capability was added at a later stage in the CSI spec,
a test that depended on readonly capability was being skipped. This
change adds PUBLISH_READONLY capability to the mock driver controller
to avoid skipping volume publish incompatiblity test.

Earlier:
```
Ran 60 of 61 Specs in 0.040 seconds
SUCCESS! -- 60 Passed | 0 Failed | 0 Pending | 1 Skipped
```

With this change:
```
Ran 61 of 61 Specs in 0.037 seconds
SUCCESS! -- 61 Passed | 0 Failed | 0 Pending | 0 Skipped
```