### PR TITLE
sanity: Add max volumes attached test

### DIFF
--- a/cmd/csi-sanity/sanity_test.go
+++ b/cmd/csi-sanity/sanity_test.go
@@ -42,6 +42,7 @@ func init() {
 	flag.StringVar(&config.SecretsFile, prefix+"secrets", "", "CSI secrets file")
 	flag.Int64Var(&config.TestVolumeSize, prefix+"testvolumesize", sanity.DefTestVolumeSize, "Base volume size used for provisioned volumes")
 	flag.StringVar(&config.TestVolumeParametersFile, prefix+"testvolumeparameters", "", "YAML file of volume parameters for provisioned volumes")
+	flag.BoolVar(&config.TestNodeVolumeAttachLimit, prefix+"testnodevolumeattachlimit", false, "Test node volume attach limit")
 	flag.StringVar(&config.JUnitFile, prefix+"junitfile", "", "JUnit XML output file where test results will be written")
 	flag.Parse()
 }

--- a/cmd/mock-driver/main.go
+++ b/cmd/mock-driver/main.go
@@ -32,7 +32,7 @@ func main() {
 	var config service.Config
 	flag.BoolVar(&config.DisableAttach, "disable-attach", false, "Disables RPC_PUBLISH_UNPUBLISH_VOLUME capability.")
 	flag.StringVar(&config.DriverName, "name", service.Name, "CSI driver name.")
-	flag.Int64Var(&config.AttachLimit, "attach-limit", 0, "number of attachable volumes on a node")
+	flag.Int64Var(&config.AttachLimit, "attach-limit", 2, "number of attachable volumes on a node")
 	flag.BoolVar(&config.NodeExpansionRequired, "node-expand-required", false, "Enables NodeServiceCapability_RPC_EXPAND_VOLUME capacity.")
 	flag.BoolVar(&config.DisableControllerExpansion, "disable-controller-expansion", false, "Disables ControllerServiceCapability_RPC_EXPAND_VOLUME capability.")
 	flag.BoolVar(&config.DisableOnlineExpansion, "disable-online-expansion", false, "Disables online volume expansion capability.")

--- a/hack/_apitest/api_test.go
+++ b/hack/_apitest/api_test.go
@@ -9,9 +9,10 @@ import (
 
 func TestMyDriver(t *testing.T) {
 	config := &sanity.Config{
-		TargetPath:  os.TempDir() + "/csi",
-		StagingPath: os.TempDir() + "/csi",
-		Address:     "/tmp/e2e-csi-sanity.sock",
+		TargetPath:                os.TempDir() + "/csi",
+		StagingPath:               os.TempDir() + "/csi",
+		Address:                   "/tmp/e2e-csi-sanity.sock",
+		TestNodeVolumeAttachLimit: true,
 	}
 
 	sanity.Test(t, config)

--- a/hack/_embedded/embedded_test.go
+++ b/hack/_embedded/embedded_test.go
@@ -26,9 +26,10 @@ var _ = AfterSuite(func() {})
 var _ = Describe("MyCSIDriver", func() {
 	Context("Config A", func() {
 		config := &sanity.Config{
-			TargetPath:  os.TempDir() + "/csi",
-			StagingPath: os.TempDir() + "/csi",
-			Address:     "/tmp/e2e-csi-sanity.sock",
+			TargetPath:                os.TempDir() + "/csi",
+			StagingPath:               os.TempDir() + "/csi",
+			Address:                   "/tmp/e2e-csi-sanity.sock",
+			TestNodeVolumeAttachLimit: true,
 		}
 
 		BeforeEach(func() {})

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -14,7 +14,7 @@ runTest()
 	CSI_ENDPOINT=$1 ./bin/mock-driver &
 	local pid=$!
 
-	./cmd/csi-sanity/csi-sanity $TESTARGS --csi.endpoint=$2; ret=$?
+	./cmd/csi-sanity/csi-sanity $TESTARGS --csi.endpoint=$2 --csi.testnodevolumeattachlimit; ret=$?
 	kill -9 $pid
 
 	if [ $ret -ne 0 ] ; then
@@ -27,7 +27,7 @@ runTestWithCreds()
 	CSI_ENDPOINT=$1 CSI_ENABLE_CREDS=true ./bin/mock-driver &
 	local pid=$!
 
-	./cmd/csi-sanity/csi-sanity $TESTARGS --csi.endpoint=$2 --csi.secrets=mock/mocksecret.yaml; ret=$?
+	./cmd/csi-sanity/csi-sanity $TESTARGS --csi.endpoint=$2 --csi.secrets=mock/mocksecret.yaml --csi.testnodevolumeattachlimit; ret=$?
 	kill -9 $pid
 
 	if [ $ret -ne 0 ] ; then

--- a/mock/service/controller.go
+++ b/mock/service/controller.go
@@ -166,6 +166,11 @@ func (s *service) ControllerPublishVolume(
 		}, nil
 	}
 
+	// Check attach limit before publishing only if attach limit is set.
+	if s.config.AttachLimit > 0 && s.getAttachCount(devPathKey) >= s.config.AttachLimit {
+		return nil, status.Errorf(codes.ResourceExhausted, "Cannot attach any more volumes to this node")
+	}
+
 	var roVal string
 	if req.GetReadonly() {
 		roVal = "true"

--- a/mock/service/service.go
+++ b/mock/service/service.go
@@ -148,3 +148,14 @@ func (s *service) newSnapshot(name, sourceVolumeId string, parameters map[string
 		},
 	}
 }
+
+// getAttachCount returns the number of attached volumes on the node.
+func (s *service) getAttachCount(devPathKey string) int64 {
+	var count int64
+	for _, v := range s.vols {
+		if device := v.VolumeContext[devPathKey]; device != "" {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -53,9 +53,10 @@ type Config struct {
 	Address     string
 	SecretsFile string
 
-	TestVolumeSize           int64
-	TestVolumeParametersFile string
-	TestVolumeParameters     map[string]string
+	TestVolumeSize            int64
+	TestVolumeParametersFile  string
+	TestVolumeParameters      map[string]string
+	TestNodeVolumeAttachLimit bool
 
 	JUnitFile string
 }


### PR DESCRIPTION
This adds a test for ControllerPublishVolume to check the maximum volume
attachment on a node.
It also sets max attach limit in the mock driver to 2 and adds a check
in the driver for the number of volume attachments before publishing a
new volume.

ControllerPublishVolume [Max volumes attached](https://github.com/container-storage-interface/spec/blob/release-1.0/spec.md#controllerpublishvolume-errors) error.