### PR TITLE
Add support for separate controller and node addresses

### DIFF
--- a/cmd/csi-sanity/sanity_test.go
+++ b/cmd/csi-sanity/sanity_test.go
@@ -36,6 +36,7 @@ var (
 
 func init() {
 	flag.StringVar(&config.Address, prefix+"endpoint", "", "CSI endpoint")
+	flag.StringVar(&config.ControllerAddress, prefix+"controllerendpoint", "", "CSI controller endpoint")
 	flag.BoolVar(&version, prefix+"version", false, "Version of this program")
 	flag.StringVar(&config.TargetPath, prefix+"mountdir", os.TempDir()+"/csi", "Mount point for NodePublish")
 	flag.StringVar(&config.StagingPath, prefix+"stagingdir", os.TempDir()+"/csi", "Mount point for NodeStage if staging is supported")

--- a/driver/driver-controller.go
+++ b/driver/driver-controller.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2019 Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"context"
+	"net"
+	"sync"
+
+	"google.golang.org/grpc/reflection"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc"
+)
+
+// CSIDriverControllerServer is the Controller service component of the driver.
+type CSIDriverControllerServer struct {
+	Controller csi.ControllerServer
+	Identity   csi.IdentityServer
+}
+
+// CSIDriverController is the CSI Driver Controller backend.
+type CSIDriverController struct {
+	listener         net.Listener
+	server           *grpc.Server
+	controllerServer *CSIDriverControllerServer
+	wg               sync.WaitGroup
+	running          bool
+	lock             sync.Mutex
+	creds            *CSICreds
+}
+
+func NewCSIDriverController(controllerServer *CSIDriverControllerServer) *CSIDriverController {
+	return &CSIDriverController{
+		controllerServer: controllerServer,
+	}
+}
+
+func (c *CSIDriverController) goServe(started chan<- bool) {
+	goServe(c.server, &c.wg, c.listener, started)
+}
+
+func (c *CSIDriverController) Address() string {
+	return c.listener.Addr().String()
+}
+
+func (c *CSIDriverController) Start(l net.Listener) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Set listener.
+	c.listener = l
+
+	// Create a new grpc server.
+	c.server = grpc.NewServer(
+		grpc.UnaryInterceptor(c.callInterceptor),
+	)
+
+	if c.controllerServer.Controller != nil {
+		csi.RegisterControllerServer(c.server, c.controllerServer.Controller)
+	}
+	if c.controllerServer.Identity != nil {
+		csi.RegisterIdentityServer(c.server, c.controllerServer.Identity)
+	}
+
+	reflection.Register(c.server)
+
+	waitForServer := make(chan bool)
+	c.goServe(waitForServer)
+	<-waitForServer
+	c.running = true
+	return nil
+}
+
+func (c *CSIDriverController) Stop() {
+	stop(&c.lock, &c.wg, c.server, c.running)
+}
+
+func (c *CSIDriverController) Close() {
+	c.server.Stop()
+}
+
+func (c *CSIDriverController) IsRunning() bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	return c.running
+}
+
+func (c *CSIDriverController) SetDefaultCreds() {
+	setDefaultCreds(c.creds)
+}
+
+func (c *CSIDriverController) callInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return callInterceptor(ctx, c.creds, req, info, handler)
+}

--- a/driver/driver-node.go
+++ b/driver/driver-node.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2019 Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	context "context"
+	"net"
+	"sync"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+)
+
+// CSIDriverNodeServer is the Node service component of the driver.
+type CSIDriverNodeServer struct {
+	Node     csi.NodeServer
+	Identity csi.IdentityServer
+}
+
+// CSIDriverNode is the CSI Driver Node backend.
+type CSIDriverNode struct {
+	listener   net.Listener
+	server     *grpc.Server
+	nodeServer *CSIDriverNodeServer
+	wg         sync.WaitGroup
+	running    bool
+	lock       sync.Mutex
+	creds      *CSICreds
+}
+
+func NewCSIDriverNode(nodeServer *CSIDriverNodeServer) *CSIDriverNode {
+	return &CSIDriverNode{
+		nodeServer: nodeServer,
+	}
+}
+
+func (c *CSIDriverNode) goServe(started chan<- bool) {
+	goServe(c.server, &c.wg, c.listener, started)
+}
+
+func (c *CSIDriverNode) Address() string {
+	return c.listener.Addr().String()
+}
+
+func (c *CSIDriverNode) Start(l net.Listener) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Set listener.
+	c.listener = l
+
+	// Create a new grpc server.
+	c.server = grpc.NewServer(
+		grpc.UnaryInterceptor(c.callInterceptor),
+	)
+
+	if c.nodeServer.Node != nil {
+		csi.RegisterNodeServer(c.server, c.nodeServer.Node)
+	}
+	if c.nodeServer.Identity != nil {
+		csi.RegisterIdentityServer(c.server, c.nodeServer.Identity)
+	}
+
+	reflection.Register(c.server)
+
+	waitForServer := make(chan bool)
+	c.goServe(waitForServer)
+	<-waitForServer
+	c.running = true
+	return nil
+}
+
+func (c *CSIDriverNode) Stop() {
+	stop(&c.lock, &c.wg, c.server, c.running)
+}
+
+func (c *CSIDriverNode) Close() {
+	c.server.Stop()
+}
+
+func (c *CSIDriverNode) IsRunning() bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	return c.running
+}
+
+func (c *CSIDriverNode) SetDefaultCreds() {
+	setDefaultCreds(c.creds)
+}
+
+func (c *CSIDriverNode) callInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return callInterceptor(ctx, c.creds, req, info, handler)
+}

--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -89,7 +89,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 	)
 
 	BeforeEach(func() {
-		c = csi.NewControllerClient(sc.Conn)
+		c = csi.NewControllerClient(sc.ControllerConn)
 		n = csi.NewNodeClient(sc.Conn)
 
 		cl = &Cleanup{
@@ -1259,7 +1259,7 @@ var _ = DescribeSanity("ListSnapshots [Controller Server]", func(sc *SanityConte
 	)
 
 	BeforeEach(func() {
-		c = csi.NewControllerClient(sc.Conn)
+		c = csi.NewControllerClient(sc.ControllerConn)
 
 		if !isControllerCapabilitySupported(c, csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS) {
 			Skip("ListSnapshots not supported")
@@ -1512,7 +1512,7 @@ var _ = DescribeSanity("DeleteSnapshot [Controller Server]", func(sc *SanityCont
 	)
 
 	BeforeEach(func() {
-		c = csi.NewControllerClient(sc.Conn)
+		c = csi.NewControllerClient(sc.ControllerConn)
 
 		if !isControllerCapabilitySupported(c, csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT) {
 			Skip("DeleteSnapshot not supported")
@@ -1575,7 +1575,7 @@ var _ = DescribeSanity("CreateSnapshot [Controller Server]", func(sc *SanityCont
 	)
 
 	BeforeEach(func() {
-		c = csi.NewControllerClient(sc.Conn)
+		c = csi.NewControllerClient(sc.ControllerConn)
 
 		if !isControllerCapabilitySupported(c, csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT) {
 			Skip("CreateSnapshot not supported")

--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -80,7 +80,7 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 
 	BeforeEach(func() {
 		c = csi.NewNodeClient(sc.Conn)
-		s = csi.NewControllerClient(sc.Conn)
+		s = csi.NewControllerClient(sc.ControllerConn)
 
 		controllerPublishSupported = isControllerCapabilitySupported(
 			s,


### PR DESCRIPTION
This change adds a new flag `controllerendpoint` to csi-sanity which
could be used to pass a separate controller endpoint for CSI drivers
that have separate controller and node services

It also modifies the mock driver to support separate controller and node
component mode when CSI_CONTROLLER_ENDPOINT env var is passed to it.
Two separate unix domain sockets are created and the csi-sanity connects
to the appropriate socket while running the RPCs.

Adds a new e2e test section to test this setup.

Fixes #142 