### PR TITLE
Add '--csi.junitfile` flag

### DIFF
--- a/cmd/csi-sanity/sanity_test.go
+++ b/cmd/csi-sanity/sanity_test.go
@@ -42,6 +42,7 @@ func init() {
 	flag.StringVar(&config.SecretsFile, prefix+"secrets", "", "CSI secrets file")
 	flag.Int64Var(&config.TestVolumeSize, prefix+"testvolumesize", sanity.DefTestVolumeSize, "Base volume size used for provisioned volumes")
 	flag.StringVar(&config.TestVolumeParametersFile, prefix+"testvolumeparameters", "", "YAML file of volume parameters for provisioned volumes")
+	flag.StringVar(&config.JUnitFile, prefix+"junitfile", "", "JUnit XML output file where test results will be written")
 	flag.Parse()
 }
 

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc"
 
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 )
 
@@ -55,6 +56,8 @@ type Config struct {
 	TestVolumeSize           int64
 	TestVolumeParametersFile string
 	TestVolumeParameters     map[string]string
+
+	JUnitFile string
 }
 
 // SanityContext holds the variables that each test can depend on. It
@@ -88,7 +91,13 @@ func Test(t *testing.T, reqConfig *Config) {
 
 	registerTestsInGinkgo(sc)
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "CSI Driver Test Suite")
+
+	var specReporters []Reporter
+	if reqConfig.JUnitFile != "" {
+		junitReporter := reporters.NewJUnitReporter(reqConfig.JUnitFile)
+		specReporters = append(specReporters, junitReporter)
+	}
+	RunSpecsWithDefaultAndCustomReporters(t, "CSI Driver Test Suite", specReporters)
 	sc.Conn.Close()
 }
 


### PR DESCRIPTION
This flag specifies a JUnit XML file which contains test results.

Fixes https://github.com/kubernetes-csi/csi-test/issues/146