### PR TITLE
mock: fix log format string

### DIFF
--- a/mock/service/controller.go
+++ b/mock/service/controller.go
@@ -508,7 +508,7 @@ func (s *service) ControllerExpandVolume(
 
 	// Check to see if the volume already satisfied request size.
 	if v.CapacityBytes == requestBytes {
-		log.WithField("volumeID", v.VolumeId).Infof("Volume capacity is already %s, no need to expand", requestBytes)
+		log.WithField("volumeID", v.VolumeId).Infof("Volume capacity is already %d, no need to expand", requestBytes)
 		return resp, nil
 	}
 


### PR DESCRIPTION
Found with "go vet":
  mock/service/controller.go:511: Entry.Infof format %s has arg requestBytes of wrong type int64