### PR TITLE
sanity: close old connection when creating a new one

### DIFF
--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -123,6 +123,9 @@ func (sc *SanityContext) setup() {
 	// dynamically (and differently!) in a BeforeEach, so only
 	// reuse the connection if the address is still the same.
 	if sc.Conn == nil || sc.connAddress != sc.Config.Address {
+		if sc.Conn != nil {
+			sc.Conn.Close()
+		}
 		By("connecting to CSI driver")
 		sc.Conn, err = utils.Connect(sc.Config.Address)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
When not reusing an old connection because the address has changed, we
should better close the old connection. Otherwise gRPC keeps
attempting to connect to it, which leads to more and more log output
the more old connection we leave open.