### PR TITLE
Change image tag to v1.0-canary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 IMAGE_NAME = quay.io/k8scsi/mock-driver
-IMAGE_VERSION = v1.0.2
+IMAGE_VERSION = v1.0-canary
 APP := ./bin/mock
 
 


### PR DESCRIPTION
We should not hardcode official release versions in the Makefile.

The v1.0.2 image just got overridden. @lpabon can you figure out how to restore the original 1.0.2 image?