### PR TITLE
make controller expansion capacity configurable

### DIFF
--- a/cmd/mock-driver/main.go
+++ b/cmd/mock-driver/main.go
@@ -34,6 +34,7 @@ func main() {
 	flag.StringVar(&config.DriverName, "name", service.Name, "CSI driver name.")
 	flag.Int64Var(&config.AttachLimit, "attach-limit", 0, "number of attachable volumes on a node")
 	flag.BoolVar(&config.NodeExpansionRequired, "node-expand-required", false, "Enables NodeServiceCapability_RPC_EXPAND_VOLUME capacity.")
+	flag.BoolVar(&config.DisableControllerExpansion, "disable-controller-expansion", false, "Disables ControllerServiceCapability_RPC_EXPAND_VOLUME capability.")
 	flag.Parse()
 
 	endpoint := os.Getenv("CSI_ENDPOINT")

--- a/mock/service/controller.go
+++ b/mock/service/controller.go
@@ -386,13 +386,6 @@ func (s *service) ControllerGetCapabilities(
 				},
 			},
 		},
-		{
-			Type: &csi.ControllerServiceCapability_Rpc{
-				Rpc: &csi.ControllerServiceCapability_RPC{
-					Type: csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
-				},
-			},
-		},
 	}
 
 	if !s.config.DisableAttach {
@@ -400,6 +393,16 @@ func (s *service) ControllerGetCapabilities(
 			Type: &csi.ControllerServiceCapability_Rpc{
 				Rpc: &csi.ControllerServiceCapability_RPC{
 					Type: csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
+				},
+			},
+		})
+	}
+
+	if !s.config.DisableControllerExpansion {
+		caps = append(caps, &csi.ControllerServiceCapability{
+			Type: &csi.ControllerServiceCapability_Rpc{
+				Rpc: &csi.ControllerServiceCapability_RPC{
+					Type: csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 				},
 			},
 		})

--- a/mock/service/service.go
+++ b/mock/service/service.go
@@ -27,10 +27,11 @@ var Manifest = map[string]string{
 }
 
 type Config struct {
-	DisableAttach         bool
-	DriverName            string
-	AttachLimit           int64
-	NodeExpansionRequired bool
+	DisableAttach              bool
+	DriverName                 string
+	AttachLimit                int64
+	NodeExpansionRequired      bool
+	DisableControllerExpansion bool
 }
 
 // Service is the CSI Mock service provider.


### PR DESCRIPTION
Make controller capacity `ControllerServiceCapability_RPC_EXPAND_VOLUME` configurable so that we can test a driver that doesn't support expansion. See https://github.com/kubernetes-csi/csi-test/pull/160#discussion_r254461959