### PR TITLE
Add fsnotify dep workaround

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -57,6 +57,10 @@
   name = "gopkg.in/yaml.v2"
   version = "v2.1.1"
 
+[[override]]
+  name = "gopkg.in/fsnotify.v1"
+  source = "https://github.com/fsnotify/fsnotify.git"
+
 [prune]
   go-tests = true
   unused-packages = true


### PR DESCRIPTION
This is a workaround for https://github.com/golang/dep/issues/1799.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>