### PR TITLE
sanity: avoid nil access for connection

### DIFF
--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -139,7 +139,9 @@ func Test(t *testing.T, reqConfig *Config) {
 		specReporters = append(specReporters, junitReporter)
 	}
 	RunSpecsWithDefaultAndCustomReporters(t, "CSI Driver Test Suite", specReporters)
-	sc.Conn.Close()
+	if sc.Conn != nil {
+		sc.Conn.Close()
+	}
 }
 
 func GinkgoTest(reqConfig *Config) {


### PR DESCRIPTION
The assumption that sc.conn always gets set turned out to be
false. The reason probably was running with such a high number of
Ginkgo nodes that some nodes never had to execute any test.