### PR TITLE
Add missing expand volume capability

### DIFF
--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -117,6 +117,7 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 				case csi.NodeServiceCapability_RPC_UNKNOWN:
 				case csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME:
 				case csi.NodeServiceCapability_RPC_GET_VOLUME_STATS:
+				case csi.NodeServiceCapability_RPC_EXPAND_VOLUME:
 				default:
 					Fail(fmt.Sprintf("Unknown capability: %v\n", cap.GetRpc().GetType()))
 				}


### PR DESCRIPTION
Without this patch, the validation of a node service that implements volume expansion always fails:

```
• Failure [0.001 seconds]
AWS EBS CSI Driver
/home/fjb/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/sanity/sanity_test.go:64
  Node Service
  /home/fjb/pkg/mod/github.com/kubernetes-csi/csi-test@v1.1.1/pkg/sanity/tests.go:44
    NodeGetCapabilities
    /home/fjb/pkg/mod/github.com/kubernetes-csi/csi-test@v1.1.1/pkg/sanity/node.go:108
      should return appropriate capabilities [It]
      /home/fjb/pkg/mod/github.com/kubernetes-csi/csi-test@v1.1.1/pkg/sanity/node.go:109

      Unknown capability: EXPAND_VOLUME

```

/kind bug
/assign @gnufied 