### PR TITLE
e2e.sh: simplify cleanup

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -7,86 +7,70 @@ UDS_CONTROLLER="/tmp/e2e-csi-sanity-ctrl.sock"
 CSI_ENDPOINTS="$CSI_ENDPOINTS ${UDS}"
 CSI_MOCK_VERSION="master"
 
+# cleanup mock_driver_pid files...
+cleanup () {
+    local pid="$1"
+    shift
+    kill -9 "$pid"
+    # We don't care about the 'hack/e2e.sh: line 15: 117018 Killed                  CSI_ENDPOINT=$1 ./bin/mock-driver'
+    wait "$pid" 2>/dev/null
+    rm -f "$@"
+}
+
 #
 # $1 - endpoint for mock.
 # $2 - endpoint for csi-sanity in Grpc format.
 #      See https://github.com/grpc/grpc/blob/master/doc/naming.md
 runTest()
-{
+(
 	CSI_ENDPOINT=$1 ./bin/mock-driver &
 	local pid=$!
+        trap 'cleanup $pid $1' EXIT
 
-	./cmd/csi-sanity/csi-sanity $TESTARGS --csi.endpoint=$2 --csi.testnodevolumeattachlimit; ret=$?
-	kill -9 $pid
-
-	if [ $ret -ne 0 ] ; then
-		exit $ret
-	fi
-}
+	./cmd/csi-sanity/csi-sanity $TESTARGS --csi.endpoint=$2 --csi.testnodevolumeattachlimit
+)
 
 runTestWithDifferentAddresses()
-{
+(
 	CSI_ENDPOINT=$1 CSI_CONTROLLER_ENDPOINT=$2 ./bin/mock-driver &
 	local pid=$!
+        trap 'cleanup $pid $1' EXIT
 
-	./cmd/csi-sanity/csi-sanity $TESTARGS --csi.endpoint=$1 --csi.controllerendpoint=$2; ret=$?
-	kill -9 $pid
-
-	if [ $ret -ne 0 ] ; then
-		exit $ret
-	fi
-}
+	./cmd/csi-sanity/csi-sanity $TESTARGS --csi.endpoint=$1 --csi.controllerendpoint=$2
+)
 
 runTestWithCreds()
-{
+(
 	CSI_ENDPOINT=$1 CSI_ENABLE_CREDS=true ./bin/mock-driver &
 	local pid=$!
+        trap 'cleanup $pid $1' EXIT
 
-	./cmd/csi-sanity/csi-sanity $TESTARGS --csi.endpoint=$2 --csi.secrets=mock/mocksecret.yaml --csi.testnodevolumeattachlimit; ret=$?
-	kill -9 $pid
-
-	if [ $ret -ne 0 ] ; then
-		exit $ret
-	fi
-}
+	./cmd/csi-sanity/csi-sanity $TESTARGS --csi.endpoint=$2 --csi.secrets=mock/mocksecret.yaml --csi.testnodevolumeattachlimit
+)
 
 runTestAPI()
-{
+(
 	CSI_ENDPOINT=$1 ./bin/mock-driver &
 	local pid=$!
+        trap 'cleanup $pid $1' EXIT
 
-	GOCACHE=off go test -v ./hack/_apitest/api_test.go; ret=$?
-
-	if [ $ret -ne 0 ] ; then
-		exit $ret
-	fi
-
-	GOCACHE=off go test -v ./hack/_embedded/embedded_test.go; ret=$?
-	kill -9 $pid
-
-	if [ $ret -ne 0 ] ; then
-		exit $ret
-	fi
-}
+	GOCACHE=off go test -v ./hack/_apitest/api_test.go && \
+	GOCACHE=off go test -v ./hack/_embedded/embedded_test.go
+)
 
 runTestAPIWithCustomTargetPaths()
-{
+(
 	CSI_ENDPOINT=$1 ./bin/mock-driver &
 	local pid=$!
+        trap 'cleanup $pid $1' EXIT
 
 	# Running a specific test to verify that the custom target paths are called
 	# a deterministic number of times.
-	GOCACHE=off go test -v ./hack/_apitest2/api_test.go -ginkgo.focus="NodePublishVolume"; ret=$?
-
-	if [ $ret -ne 0 ] ; then
-		exit $ret
-	fi
-}
+	GOCACHE=off go test -v ./hack/_apitest2/api_test.go -ginkgo.focus="NodePublishVolume"
+)
 
 runTestWithCustomTargetPaths()
-{
-	CSI_ENDPOINT=$1 ./bin/mock-driver &
-	local pid=$!
+(
 
 	# Create a script for custom target path creation.
 	echo '#!/bin/bash
@@ -104,6 +88,10 @@ rm -rf $@
 	local creationscriptpath="$PWD/custompathcreation.bash"
 	local removalscriptpath="$PWD/custompathremoval.bash"
 
+	CSI_ENDPOINT=$1 ./bin/mock-driver &
+	local pid=$!
+        trap 'cleanup $pid $1; rm $creationscriptpath $removalscriptpath' EXIT
+
 	./cmd/csi-sanity/csi-sanity $TESTARGS \
 		--csi.endpoint=$2 \
 		--csi.mountdir="foo/target/mount" \
@@ -111,16 +99,8 @@ rm -rf $@
 		--csi.createmountpathcmd=$creationscriptpath \
 		--csi.createstagingpathcmd=$creationscriptpath \
 		--csi.removemountpathcmd=$removalscriptpath \
-		--csi.removestagingpathcmd=$removalscriptpath; ret=$?
-	kill -9 $pid
-
-	# Delete the script.
-	rm $creationscriptpath $removalscriptpath
-
-	if [ $ret -ne 0 ] ; then
-		exit $ret
-	fi
-}
+		--csi.removestagingpathcmd=$removalscriptpath
+)
 
 make
 
@@ -128,23 +108,9 @@ cd cmd/csi-sanity
   make clean install || exit 1
 cd ../..
 
-runTest "${UDS}" "${UDS}"
-rm -f $UDS
-
-runTestWithCreds "${UDS}" "${UDS}"
-rm -f $UDS
-
-runTestAPI "${UDS}"
-rm -f $UDS
-
-runTestWithDifferentAddresses "${UDS_NODE}" "${UDS_CONTROLLER}"
-rm -f $UDS_NODE
-rm -f $UDS_CONTROLLER
-
-runTestAPIWithCustomTargetPaths "${UDS}"
-rm -rf $UDS
-
+runTest "${UDS}" "${UDS}" &&
+runTestWithCreds "${UDS}" "${UDS}" &&
+runTestAPI "${UDS}" &&
+runTestWithDifferentAddresses "${UDS_NODE}" "${UDS_CONTROLLER}" &&
+runTestAPIWithCustomTargetPaths "${UDS}" &&
 runTestWithCustomTargetPaths "${UDS}" "${UDS}"
-rm -rf $UDS
-
-exit 0


### PR DESCRIPTION
All cleanup actions are now done via EXIT traps in subshells. That
removes the need to capture return codes.

The "Killed" message for the mock driver is removed, it looked odd to
run the script and have it end with that message.

Previously, "make test" when invoked from another script hang with
some mock driver processes still running. These changes fix that.