### PR TITLE
sanity: use correct path during cleanup

### DIFF
--- a/pkg/sanity/cleanup.go
+++ b/pkg/sanity/cleanup.go
@@ -88,7 +88,7 @@ func (cl *Cleanup) DeleteVolumes() {
 			ctx,
 			&csi.NodeUnpublishVolumeRequest{
 				VolumeId:   info.VolumeID,
-				TargetPath: cl.Context.Config.TargetPath,
+				TargetPath: cl.Context.targetPath,
 			},
 		); err != nil {
 			logger.Printf("warning: NodeUnpublishVolume: %s", err)
@@ -99,7 +99,7 @@ func (cl *Cleanup) DeleteVolumes() {
 				ctx,
 				&csi.NodeUnstageVolumeRequest{
 					VolumeId:          info.VolumeID,
-					StagingTargetPath: cl.Context.Config.StagingPath,
+					StagingTargetPath: cl.Context.stagingPath,
 				},
 			); err != nil {
 				logger.Printf("warning: NodeUnstageVolume: %s", err)


### PR DESCRIPTION
https://github.com/kubernetes-csi/csi-test/pull/159 introduced the
ability to use different paths for each tests via external commands or
callbacks, but it missed two lines in the cleanup code which also have
to use the actual paths instead of the configured paths.