### PR TITLE
update to Go 1.12.4

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -54,8 +54,8 @@ runTestAPI()
 	local pid=$!
         trap 'cleanup $pid $1' EXIT
 
-	GOCACHE=off go test -v ./hack/_apitest/api_test.go && \
-	GOCACHE=off go test -v ./hack/_embedded/embedded_test.go
+	go test -count=1 -v ./hack/_apitest/api_test.go && \
+	go test -count=1 -v ./hack/_embedded/embedded_test.go
 )
 
 runTestAPIWithCustomTargetPaths()
@@ -66,7 +66,7 @@ runTestAPIWithCustomTargetPaths()
 
 	# Running a specific test to verify that the custom target paths are called
 	# a deterministic number of times.
-	GOCACHE=off go test -v ./hack/_apitest2/api_test.go -ginkgo.focus="NodePublishVolume"
+	go test -count=1 -v ./hack/_apitest2/api_test.go -ginkgo.focus="NodePublishVolume"
 )
 
 runTestWithCustomTargetPaths()

--- a/release-tools/travis.yml
+++ b/release-tools/travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 matrix:
   include:
-  - go: 1.11.1
+  - go: 1.12.4
 before_script:
 - mkdir -p bin
 - wget https://github.com/golang/dep/releases/download/v0.5.1/dep-linux-amd64 -O bin/dep


### PR DESCRIPTION
Imports the latest csi-release-tools and fixes a compatibility problem in e8500f2.
