### PR TITLE
Reuse testing api

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -276,6 +276,7 @@
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",
     "google.golang.org/grpc/connectivity",
+    "google.golang.org/grpc/keepalive",
     "google.golang.org/grpc/reflection",
     "google.golang.org/grpc/status",
     "gopkg.in/yaml.v2",

--- a/pkg/sanity/cleanup.go
+++ b/pkg/sanity/cleanup.go
@@ -88,7 +88,7 @@ func (cl *Cleanup) DeleteVolumes() {
 			ctx,
 			&csi.NodeUnpublishVolumeRequest{
 				VolumeId:   info.VolumeID,
-				TargetPath: cl.Context.targetPath,
+				TargetPath: cl.Context.TargetPath,
 			},
 		); err != nil {
 			logger.Printf("warning: NodeUnpublishVolume: %s", err)
@@ -99,7 +99,7 @@ func (cl *Cleanup) DeleteVolumes() {
 				ctx,
 				&csi.NodeUnstageVolumeRequest{
 					VolumeId:          info.VolumeID,
-					StagingTargetPath: cl.Context.stagingPath,
+					StagingTargetPath: cl.Context.StagingPath,
 				},
 			); err != nil {
 				logger.Printf("warning: NodeUnstageVolume: %s", err)

--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -379,7 +379,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 		})
 
 		It("should fail when no volume capabilities are provided", func() {
-			name := uniqueString("sanity-controller-create-no-volume-capabilities")
+			name := UniqueString("sanity-controller-create-no-volume-capabilities")
 			vol, err := c.CreateVolume(
 				context.Background(),
 				&csi.CreateVolumeRequest{
@@ -399,7 +399,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 		It("should return appropriate values SingleNodeWriter NoCapacity Type:Mount", func() {
 
 			By("creating a volume")
-			name := uniqueString("sanity-controller-create-single-no-capacity")
+			name := UniqueString("sanity-controller-create-single-no-capacity")
 
 			vol, err := c.CreateVolume(
 				context.Background(),
@@ -441,7 +441,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 		It("should return appropriate values SingleNodeWriter WithCapacity 1Gi Type:Mount", func() {
 
 			By("creating a volume")
-			name := uniqueString("sanity-controller-create-single-with-capacity")
+			name := UniqueString("sanity-controller-create-single-with-capacity")
 
 			vol, err := c.CreateVolume(
 				context.Background(),
@@ -490,7 +490,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 		It("should not fail when requesting to create a volume with already existing name and same capacity.", func() {
 
 			By("creating a volume")
-			name := uniqueString("sanity-controller-create-twice")
+			name := UniqueString("sanity-controller-create-twice")
 			size := TestVolumeSize(sc)
 
 			vol1, err := c.CreateVolume(
@@ -564,7 +564,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 		It("should fail when requesting to create a volume with already existing name and different capacity.", func() {
 
 			By("creating a volume")
-			name := uniqueString("sanity-controller-create-twice-different")
+			name := UniqueString("sanity-controller-create-twice-different")
 			size1 := TestVolumeSize(sc)
 
 			vol1, err := c.CreateVolume(
@@ -693,13 +693,13 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 			}
 
 			By("creating a volume")
-			vol1Name := uniqueString("sanity-controller-source-vol")
+			vol1Name := UniqueString("sanity-controller-source-vol")
 			vol1Req := MakeCreateVolumeReq(sc, vol1Name)
 			volume1, err := c.CreateVolume(context.Background(), vol1Req)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating a snapshot")
-			snapName := uniqueString("sanity-controller-snap-from-vol")
+			snapName := UniqueString("sanity-controller-snap-from-vol")
 			snapReq := MakeCreateSnapshotReq(sc, snapName, volume1.GetVolume().GetVolumeId(), nil)
 			snap, err := c.CreateSnapshot(context.Background(), snapReq)
 			Expect(err).NotTo(HaveOccurred())
@@ -707,7 +707,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 			verifySnapshotInfo(snap.GetSnapshot())
 
 			By("creating a volume from source snapshot")
-			vol2Name := uniqueString("sanity-controller-vol-from-snap")
+			vol2Name := UniqueString("sanity-controller-vol-from-snap")
 			vol2Req := MakeCreateVolumeReq(sc, vol2Name)
 			vol2Req.VolumeContentSource = &csi.VolumeContentSource{
 				Type: &csi.VolumeContentSource_Snapshot{
@@ -741,7 +741,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 			}
 
 			By("creating a volume from source snapshot")
-			volName := uniqueString("sanity-controller-vol-from-snap")
+			volName := UniqueString("sanity-controller-vol-from-snap")
 			volReq := MakeCreateVolumeReq(sc, volName)
 			volReq.VolumeContentSource = &csi.VolumeContentSource{
 				Type: &csi.VolumeContentSource_Snapshot{
@@ -763,13 +763,13 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 			}
 
 			By("creating a volume")
-			vol1Name := uniqueString("sanity-controller-source-vol")
+			vol1Name := UniqueString("sanity-controller-source-vol")
 			vol1Req := MakeCreateVolumeReq(sc, vol1Name)
 			volume1, err := c.CreateVolume(context.Background(), vol1Req)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating a volume from source volume")
-			vol2Name := uniqueString("sanity-controller-vol-from-vol")
+			vol2Name := UniqueString("sanity-controller-vol-from-vol")
 			vol2Req := MakeCreateVolumeReq(sc, vol2Name)
 			vol2Req.VolumeContentSource = &csi.VolumeContentSource{
 				Type: &csi.VolumeContentSource_Volume{
@@ -798,7 +798,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 			}
 
 			By("creating a volume from source snapshot")
-			volName := uniqueString("sanity-controller-vol-from-snap")
+			volName := UniqueString("sanity-controller-vol-from-snap")
 			volReq := MakeCreateVolumeReq(sc, volName)
 			volReq.VolumeContentSource = &csi.VolumeContentSource{
 				Type: &csi.VolumeContentSource_Volume{
@@ -853,7 +853,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 
 			// Create Volume First
 			By("creating a volume")
-			name := uniqueString("sanity-controller-create-appropriate")
+			name := UniqueString("sanity-controller-create-appropriate")
 
 			vol, err := c.CreateVolume(
 				context.Background(),
@@ -913,7 +913,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 
 			// Create Volume First
 			By("creating a single node writer volume")
-			name := uniqueString("sanity-controller-validate-nocaps")
+			name := UniqueString("sanity-controller-validate-nocaps")
 
 			vol, err := c.CreateVolume(
 				context.Background(),
@@ -968,7 +968,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 
 			// Create Volume First
 			By("creating a single node writer volume")
-			name := uniqueString("sanity-controller-validate")
+			name := UniqueString("sanity-controller-validate")
 
 			vol, err := c.CreateVolume(
 				context.Background(),
@@ -1120,7 +1120,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 
 			// Create Volume First
 			By("creating a single node writer volume")
-			name := uniqueString("sanity-controller-publish")
+			name := UniqueString("sanity-controller-publish")
 
 			vol, err := c.CreateVolume(
 				context.Background(),
@@ -1228,14 +1228,14 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 			createdVols := map[string]string{}
 			By("creating volumes")
 			for i := int64(0); i < nodeInfo.MaxVolumesPerNode; i++ {
-				name := uniqueString(fmt.Sprintf("sanity-max-attach-limit-vol-%d", i))
+				name := UniqueString(fmt.Sprintf("sanity-max-attach-limit-vol-%d", i))
 				volID, err := CreateAndControllerPublishVolume(sc, c, name, nid)
 				Expect(err).NotTo(HaveOccurred())
 				cl.RegisterVolume(name, VolumeInfo{VolumeID: volID, NodeID: nid})
 				createdVols[name] = volID
 			}
 
-			extraVolName := uniqueString("sanity-max-attach-limit-vol+1")
+			extraVolName := UniqueString("sanity-max-attach-limit-vol+1")
 			_, err = CreateAndControllerPublishVolume(sc, c, extraVolName, nid)
 			Expect(err).To(HaveOccurred())
 
@@ -1280,7 +1280,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 
 			// Create Volume First
 			By("creating a single node writer volume")
-			name := uniqueString("sanity-controller-wrong-node")
+			name := UniqueString("sanity-controller-wrong-node")
 
 			vol, err := c.CreateVolume(
 				context.Background(),
@@ -1353,7 +1353,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 
 			// Create Volume First
 			By("creating a single node writer volume")
-			name := uniqueString("sanity-controller-published-incompatible")
+			name := UniqueString("sanity-controller-published-incompatible")
 
 			vol, err := c.CreateVolume(
 				context.Background(),
@@ -1475,7 +1475,7 @@ var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
 
 			// Create Volume First
 			By("creating a single node writer volume")
-			name := uniqueString("sanity-controller-unpublish")
+			name := UniqueString("sanity-controller-unpublish")
 
 			vol, err := c.CreateVolume(
 				context.Background(),

--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -187,7 +187,7 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 				context.Background(),
 				&csi.NodePublishVolumeRequest{
 					VolumeId:   "id",
-					TargetPath: sc.targetPath + "/target",
+					TargetPath: sc.TargetPath + "/target",
 					Secrets:    sc.Secrets.NodePublishVolumeSecret,
 				},
 			)
@@ -244,7 +244,7 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 			_, err := c.NodeStageVolume(
 				context.Background(),
 				&csi.NodeStageVolumeRequest{
-					StagingTargetPath: sc.stagingPath,
+					StagingTargetPath: sc.StagingPath,
 					VolumeCapability: &csi.VolumeCapability{
 						AccessType: &csi.VolumeCapability_Mount{
 							Mount: &csi.VolumeCapability_MountVolume{},
@@ -296,7 +296,7 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 
 			// Create Volume First
 			By("creating a single node writer volume")
-			name := uniqueString("sanity-node-stage-nocaps")
+			name := UniqueString("sanity-node-stage-nocaps")
 
 			vol, err := s.CreateVolume(
 				context.Background(),
@@ -326,7 +326,7 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 				context.Background(),
 				&csi.NodeStageVolumeRequest{
 					VolumeId:          vol.GetVolume().GetVolumeId(),
-					StagingTargetPath: sc.stagingPath,
+					StagingTargetPath: sc.StagingPath,
 					PublishContext: map[string]string{
 						"device": device,
 					},
@@ -365,7 +365,7 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 			_, err := c.NodeUnstageVolume(
 				context.Background(),
 				&csi.NodeUnstageVolumeRequest{
-					StagingTargetPath: sc.stagingPath,
+					StagingTargetPath: sc.StagingPath,
 				})
 			Expect(err).To(HaveOccurred())
 
@@ -440,7 +440,7 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 		})
 
 		It("should fail when volume does not exist on the specified path", func() {
-			name := uniqueString("sanity-node-get-volume-stats")
+			name := UniqueString("sanity-node-get-volume-stats")
 
 			By("creating a single node writer volume")
 			vol, err := s.CreateVolume(
@@ -516,7 +516,7 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
 							},
 						},
-						StagingTargetPath: sc.stagingPath,
+						StagingTargetPath: sc.StagingPath,
 						VolumeContext:     vol.GetVolume().GetVolumeContext(),
 						PublishContext:    conpubvol.GetPublishContext(),
 						Secrets:           sc.Secrets.NodeStageVolumeSecret,
@@ -529,13 +529,13 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 			By("publishing the volume on a node")
 			var stagingPath string
 			if nodeStageSupported {
-				stagingPath = sc.stagingPath
+				stagingPath = sc.StagingPath
 			}
 			nodepubvol, err := c.NodePublishVolume(
 				context.Background(),
 				&csi.NodePublishVolumeRequest{
 					VolumeId:          vol.GetVolume().GetVolumeId(),
-					TargetPath:        sc.targetPath + "/target",
+					TargetPath:        sc.TargetPath + "/target",
 					StagingTargetPath: stagingPath,
 					VolumeCapability: &csi.VolumeCapability{
 						AccessType: &csi.VolumeCapability_Mount{
@@ -574,7 +574,7 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 				context.Background(),
 				&csi.NodeUnpublishVolumeRequest{
 					VolumeId:   vol.GetVolume().GetVolumeId(),
-					TargetPath: sc.targetPath + "/target",
+					TargetPath: sc.TargetPath + "/target",
 				})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nodeunpubvol).NotTo(BeNil())
@@ -585,7 +585,7 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 					context.Background(),
 					&csi.NodeUnstageVolumeRequest{
 						VolumeId:          vol.GetVolume().GetVolumeId(),
-						StagingTargetPath: sc.stagingPath,
+						StagingTargetPath: sc.StagingPath,
 					},
 				)
 				Expect(err).NotTo(HaveOccurred())
@@ -623,7 +623,7 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 	})
 
 	It("should work", func() {
-		name := uniqueString("sanity-node-full")
+		name := UniqueString("sanity-node-full")
 
 		// Create Volume First
 		By("creating a single node writer volume")
@@ -700,7 +700,7 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
 						},
 					},
-					StagingTargetPath: sc.stagingPath,
+					StagingTargetPath: sc.StagingPath,
 					VolumeContext:     vol.GetVolume().GetVolumeContext(),
 					PublishContext:    conpubvol.GetPublishContext(),
 					Secrets:           sc.Secrets.NodeStageVolumeSecret,
@@ -713,13 +713,13 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 		By("publishing the volume on a node")
 		var stagingPath string
 		if nodeStageSupported {
-			stagingPath = sc.stagingPath
+			stagingPath = sc.StagingPath
 		}
 		nodepubvol, err := c.NodePublishVolume(
 			context.Background(),
 			&csi.NodePublishVolumeRequest{
 				VolumeId:          vol.GetVolume().GetVolumeId(),
-				TargetPath:        sc.targetPath + "/target",
+				TargetPath:        sc.TargetPath + "/target",
 				StagingTargetPath: stagingPath,
 				VolumeCapability: &csi.VolumeCapability{
 					AccessType: &csi.VolumeCapability_Mount{
@@ -744,7 +744,7 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 				context.Background(),
 				&csi.NodeGetVolumeStatsRequest{
 					VolumeId:   vol.GetVolume().GetVolumeId(),
-					VolumePath: sc.targetPath + "/target",
+					VolumePath: sc.TargetPath + "/target",
 				},
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -757,7 +757,7 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 			context.Background(),
 			&csi.NodeUnpublishVolumeRequest{
 				VolumeId:   vol.GetVolume().GetVolumeId(),
-				TargetPath: sc.targetPath + "/target",
+				TargetPath: sc.TargetPath + "/target",
 			})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nodeunpubvol).NotTo(BeNil())
@@ -768,7 +768,7 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 				context.Background(),
 				&csi.NodeUnstageVolumeRequest{
 					VolumeId:          vol.GetVolume().GetVolumeId(),
-					StagingTargetPath: sc.stagingPath,
+					StagingTargetPath: sc.StagingPath,
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -131,8 +131,8 @@ type SanityContext struct {
 	controllerConnAddress string
 
 	// Target and staging paths derived from the sanity config.
-	targetPath  string
-	stagingPath string
+	TargetPath  string
+	StagingPath string
 }
 
 // Test will test the CSI driver at the specified address by
@@ -176,7 +176,7 @@ func GinkgoTest(reqConfig *Config) {
 	registerTestsInGinkgo(sc)
 }
 
-func (sc *SanityContext) setup() {
+func (sc *SanityContext) Setup() {
 	var err error
 
 	if len(sc.Config.SecretsFile) > 0 {
@@ -220,18 +220,18 @@ func (sc *SanityContext) setup() {
 	// If callback function for creating target dir is specified, use it.
 	targetPath, err := createMountTargetLocation(sc.Config.TargetPath, sc.Config.CreateTargetPathCmd, sc.Config.CreateTargetDir, sc.Config.CreatePathCmdTimeout)
 	Expect(err).NotTo(HaveOccurred(), "failed to create target directory %s", targetPath)
-	sc.targetPath = targetPath
+	sc.TargetPath = targetPath
 
 	// If callback function for creating staging dir is specified, use it.
 	stagingPath, err := createMountTargetLocation(sc.Config.StagingPath, sc.Config.CreateStagingPathCmd, sc.Config.CreateStagingDir, sc.Config.CreatePathCmdTimeout)
 	Expect(err).NotTo(HaveOccurred(), "failed to create staging directory %s", stagingPath)
-	sc.stagingPath = stagingPath
+	sc.StagingPath = stagingPath
 }
 
-func (sc *SanityContext) teardown() {
+func (sc *SanityContext) Teardown() {
 	// Delete the created paths if any.
-	removeMountTargetLocation(sc.targetPath, sc.Config.RemoveTargetPathCmd, sc.Config.RemoveTargetPath, sc.Config.RemovePathCmdTimeout)
-	removeMountTargetLocation(sc.stagingPath, sc.Config.RemoveStagingPathCmd, sc.Config.RemoveStagingPath, sc.Config.RemovePathCmdTimeout)
+	removeMountTargetLocation(sc.TargetPath, sc.Config.RemoveTargetPathCmd, sc.Config.RemoveTargetPath, sc.Config.RemovePathCmdTimeout)
+	removeMountTargetLocation(sc.StagingPath, sc.Config.RemoveStagingPathCmd, sc.Config.RemoveStagingPath, sc.Config.RemovePathCmdTimeout)
 
 	// We intentionally do not close the connection to the CSI
 	// driver here because the large amount of connection attempts
@@ -335,11 +335,11 @@ func loadSecrets(path string) (*CSISecrets, error) {
 	return &creds, nil
 }
 
-var uniqueSuffix = "-" + pseudoUUID()
+var uniqueSuffix = "-" + PseudoUUID()
 
-// pseudoUUID returns a unique string generated from random
+// PseudoUUID returns a unique string generated from random
 // bytes, empty string in case of error.
-func pseudoUUID() string {
+func PseudoUUID() string {
 	b := make([]byte, 8)
 	if _, err := rand.Read(b); err != nil {
 		// Shouldn't happen?!
@@ -348,9 +348,9 @@ func pseudoUUID() string {
 	return fmt.Sprintf("%08X-%08X", b[0:4], b[4:8])
 }
 
-// uniqueString returns a unique string by appending a random
+// UniqueString returns a unique string by appending a random
 // number. In case of an error, just the prefix is returned, so it
 // alone should already be fairly unique.
-func uniqueString(prefix string) string {
+func UniqueString(prefix string) string {
 	return prefix + uniqueSuffix
 }

--- a/pkg/sanity/tests.go
+++ b/pkg/sanity/tests.go
@@ -43,13 +43,13 @@ func registerTestsInGinkgo(sc *SanityContext) {
 	for _, test := range tests {
 		Describe(test.text, func() {
 			BeforeEach(func() {
-				sc.setup()
+				sc.Setup()
 			})
 
 			test.body(sc)
 
 			AfterEach(func() {
-				sc.teardown()
+				sc.Teardown()
 			})
 		})
 	}

--- a/utils/grpcutil.go
+++ b/utils/grpcutil.go
@@ -25,6 +25,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/keepalive"
 )
 
 // Connect address by grpc
@@ -40,6 +41,11 @@ func Connect(address string) (*grpc.ClientConn, error) {
 					return net.DialTimeout("unix", u.Path, timeout)
 				}))
 	}
+	// This is necessary when connecting via TCP and does not hurt
+	// when using Unix domain sockets. It ensures that gRPC detects a dead connection
+	// in a timely manner.
+	dialOptions = append(dialOptions,
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{PermitWithoutStream: true}))
 
 	conn, err := grpc.Dial(address, dialOptions...)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This enables better testing over TCP (dead connection detection) and reuse of the csi-sanity infrastructure in custom test suites.

**Special notes for your reviewer**:

This *extends* the API of the package and thus is a minor update.

**Does this PR introduce a user-facing change?**:
```release-note
the csi-sanity connection setup can be used in custom test suites
```
