### PR TITLE
CHANGELOG-2.0.md: initial change log for 2.0.x

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,0 +1,7 @@
+# Changelog since v2.0.0
+
+## Other Notable Changes
+* csi-sanity: support topology during node testing ([#200](https://github.com/kubernetes-csi/csi-test/pull/200))
+* csi-sanity: avoid leaking volumes during volume list testing ([#195](https://github.com/kubernetes-csi/csi-test/pull/195))
+* csi-sanity: enable reuse of more methods ([#193](https://github.com/kubernetes-csi/csi-test/pull/193))
+* csi-sanity: use correct path during cleanup ([#187](https://github.com/kubernetes-csi/csi-test/pull/187))


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

Let's merge this changelog and then tag 2.0.1 release. Several bug fixes have accumulated that downstream users can only vendor cleanly if we tag a release.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
