### PR TITLE
Implement ControllerExpandVolume tests for Online expansion.

### DIFF
--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -65,7 +65,10 @@ type Config struct {
 	ControllerAddress string
 	SecretsFile       string
 
-	TestVolumeSize            int64
+	TestVolumeSize int64
+
+	// Target size for ExpandVolume requests. If not specified it defaults to TestVolumeSize + 1 GB
+	TestVolumeExpandSize      int64
 	TestVolumeParametersFile  string
 	TestVolumeParameters      map[string]string
 	TestNodeVolumeAttachLimit bool


### PR DESCRIPTION
Adds tests for ControllerExpandVolume capability. Tests for OFFLINE
VolumeExpansion are not included.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind test-case

**What this PR does / why we need it**:
csi-test do not support ControllerExpandVolume capability yet. This PR adds three very basic tests for this.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:
Not sure about the /kind test-case but there was no fitting kind ;)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added tests for ControllerExpandVolume
```
