### PR TITLE
[WIP] Implement NodeExpandVolume test

### DIFF
--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -67,6 +67,47 @@ func isPluginCapabilitySupported(c csi.IdentityClient,
 	return false
 }
 
+func isPluginCapabilityVolumeExpansionSupported(c csi.IdentityClient,
+	capType csi.PluginCapability_VolumeExpansion_Type,
+) bool {
+
+	caps, err := c.GetPluginCapabilities(
+		context.Background(),
+		&csi.GetPluginCapabilitiesRequest{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(caps).NotTo(BeNil())
+	Expect(caps.GetCapabilities()).NotTo(BeNil())
+
+	for _, cap := range caps.GetCapabilities() {
+		if cap.GetVolumeExpansion() != nil && cap.GetVolumeExpansion().GetType() == capType {
+			return true
+		}
+	}
+	return false
+}
+
+func isControllerPublishSupported(c csi.ControllerClient) bool {
+	return isControllerCapabilitySupported(
+		c,
+		csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME)
+}
+
+func isControllerExpandVolumeSupported(c csi.ControllerClient) bool {
+	return isControllerCapabilitySupported(c, csi.ControllerServiceCapability_RPC_EXPAND_VOLUME)
+}
+func isNodeStageSupported(c csi.NodeClient) bool {
+	return isNodeCapabilitySupported(c, csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME)
+}
+
+func isNodeVolumeStatsSupported(c csi.NodeClient) bool {
+	return isNodeCapabilitySupported(c, csi.NodeServiceCapability_RPC_GET_VOLUME_STATS)
+}
+
+func isNodeVolumeExpandSupported(c csi.NodeClient) bool {
+	return isNodeCapabilitySupported(c, csi.NodeServiceCapability_RPC_EXPAND_VOLUME)
+
+}
+
 var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 	var (
 		cl *Cleanup
@@ -82,11 +123,9 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 		c = csi.NewNodeClient(sc.Conn)
 		s = csi.NewControllerClient(sc.ControllerConn)
 
-		controllerPublishSupported = isControllerCapabilitySupported(
-			s,
-			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME)
-		nodeStageSupported = isNodeCapabilitySupported(c, csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME)
-		nodeVolumeStatsSupported = isNodeCapabilitySupported(c, csi.NodeServiceCapability_RPC_GET_VOLUME_STATS)
+		controllerPublishSupported = isControllerPublishSupported(s)
+		nodeStageSupported = isNodeStageSupported(c)
+		nodeVolumeStatsSupported = isNodeVolumeStatsSupported(c)
 		cl = &Cleanup{
 			Context:                    sc,
 			NodeClient:                 c,
@@ -813,3 +852,299 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 		Expect(err).NotTo(HaveOccurred())
 	})
 })
+
+type VolumeGetter interface {
+	GetVolume() *csi.Volume
+}
+
+func getTotalBytesFromUsageList(usage []*csi.VolumeUsage) int64 {
+	for _, u := range usage {
+		if u.Unit == csi.VolumeUsage_BYTES {
+			return u.Total
+		}
+	}
+	return 0
+}
+
+var _ = DescribeSanity("ExpandVolume [Node Server]", func(sc *SanityContext) {
+	var (
+		c  csi.ControllerClient
+		n  csi.NodeClient
+		i  csi.IdentityClient
+		cl *Cleanup
+	)
+	BeforeEach(func() {
+		i = csi.NewIdentityClient(sc.ControllerConn)
+		c = csi.NewControllerClient(sc.ControllerConn)
+		n = csi.NewNodeClient(sc.Conn)
+		if !isNodeVolumeExpandSupported(n) {
+			Skip("NodeExpandVolume not supported")
+		}
+		if !isPluginCapabilityVolumeExpansionSupported(i, csi.PluginCapability_VolumeExpansion_ONLINE) {
+			Skip("VolumeExpansion Online is not supported")
+		}
+		cl = &Cleanup{
+			ControllerClient: c,
+			NodeClient:       n,
+			Context:          sc,
+		}
+	})
+	AfterEach(func() {
+		cl.DeleteVolumes()
+	})
+
+	It("should work", func() {
+		name := UniqueString("sanity-node-expand-volume")
+		ni, err := n.NodeGetInfo(context.TODO(), &csi.NodeGetInfoRequest{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ni).NotTo(BeNil())
+		vol := createVolume(sc, cl, name, c)
+		pub := maybeControllerPublishVolume(sc, cl, c, name, vol, ni.GetNodeId())
+		_ = maybeNodeStageVolume(sc, n, vol, pub.GetPublishContext())
+		_ = nodePublishVolume(sc, n, vol, pub.GetPublishContext())
+
+		stat, _ := maybeGetVolumeStats(n, vol, sc.TargetPath+"/target")
+		var beforeTotalBytes int64
+		if stat != nil {
+			beforeTotalBytes = getTotalBytesFromUsageList(stat.Usage)
+		}
+		_ = maybeControllerExpandVolume(sc, c, vol)
+		By("Expanding the volume on a node")
+		rsp, err := n.NodeExpandVolume(
+			context.Background(),
+			&csi.NodeExpandVolumeRequest{
+				VolumeId: vol.GetVolume().GetVolumeId(),
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: TestVolumeExpandSize(sc),
+				},
+				VolumePath: sc.TargetPath + "/target",
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rsp).NotTo(BeNil())
+		newStat, _ := maybeGetVolumeStats(n, vol, sc.TargetPath+"/target")
+		if newStat != nil && stat != nil {
+			Expect(getTotalBytesFromUsageList(newStat.Usage) > beforeTotalBytes).To(BeTrue())
+		}
+
+		_ = nodeUnpublishVolume(sc, n, vol)
+		_ = maybeNodeUnstageVolume(sc, n, vol)
+		_ = maybeControllerUnpublishVolume(sc, c, vol, ni.GetNodeId())
+		deleteVolume(sc, c, vol)
+
+	})
+
+})
+
+func createVolume(sc *SanityContext, cl *Cleanup, name string, c csi.ControllerClient) (rsp *csi.CreateVolumeResponse) {
+	By("Creating the volume")
+	rsp, err := c.CreateVolume(
+		context.Background(),
+		&csi.CreateVolumeRequest{
+			Name: name,
+			VolumeCapabilities: []*csi.VolumeCapability{
+				{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+			},
+			Secrets:    sc.Secrets.CreateVolumeSecret,
+			Parameters: sc.Config.TestVolumeParameters,
+		},
+	)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(rsp).NotTo(BeNil())
+	Expect(rsp.GetVolume()).NotTo(BeNil())
+	Expect(rsp.GetVolume().GetVolumeId()).NotTo(BeEmpty())
+	cl.RegisterVolume(name, VolumeInfo{VolumeID: rsp.GetVolume().GetVolumeId()})
+	return
+}
+
+func deleteVolume(sc *SanityContext, c csi.ControllerClient, vol VolumeGetter) {
+	By("cleaning up deleting the volume")
+
+	_, err := c.DeleteVolume(
+		context.Background(),
+		&csi.DeleteVolumeRequest{
+			VolumeId: vol.GetVolume().GetVolumeId(),
+			Secrets:  sc.Secrets.DeleteVolumeSecret,
+		},
+	)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func nodePublishVolume(sc *SanityContext, n csi.NodeClient, vol VolumeGetter,
+	publishContext map[string]string) (rsp *csi.NodePublishVolumeResponse) {
+	// NodePublishVolume
+	By("publishing the volume on a node")
+	var stagingPath string
+	if isNodeStageSupported(n) {
+		stagingPath = sc.StagingPath
+	}
+	rsp, err := n.NodePublishVolume(
+		context.Background(),
+		&csi.NodePublishVolumeRequest{
+			VolumeId:          vol.GetVolume().GetVolumeId(),
+			TargetPath:        sc.TargetPath + "/target",
+			StagingTargetPath: stagingPath,
+			VolumeCapability: &csi.VolumeCapability{
+				AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{},
+				},
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				},
+			},
+			VolumeContext:  vol.GetVolume().GetVolumeContext(),
+			PublishContext: publishContext,
+			Secrets:        sc.Secrets.NodePublishVolumeSecret,
+		},
+	)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(rsp).NotTo(BeNil())
+	return
+}
+
+func nodeUnpublishVolume(sc *SanityContext, n csi.NodeClient, vol VolumeGetter) (rsp *csi.NodeUnpublishVolumeResponse) {
+	By("cleaning up calling nodeunpublish")
+	rsp, err := n.NodeUnpublishVolume(
+		context.Background(),
+		&csi.NodeUnpublishVolumeRequest{
+			VolumeId:   vol.GetVolume().GetVolumeId(),
+			TargetPath: sc.TargetPath + "/target",
+		})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(rsp).NotTo(BeNil())
+	return
+}
+
+func maybeNodeStageVolume(
+	sc *SanityContext, n csi.NodeClient, vol VolumeGetter,
+	publishContext map[string]string) (rsp *csi.NodeStageVolumeResponse) {
+	if isNodeStageSupported(n) {
+
+		rsp, err := n.NodeStageVolume(
+			context.Background(),
+			&csi.NodeStageVolumeRequest{
+				VolumeId: vol.GetVolume().GetVolumeId(),
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+				StagingTargetPath: sc.StagingPath,
+				VolumeContext:     vol.GetVolume().GetVolumeContext(),
+				PublishContext:    publishContext,
+				Secrets:           sc.Secrets.NodeStageVolumeSecret,
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rsp).NotTo(BeNil())
+	}
+	return
+}
+
+func maybeNodeUnstageVolume(sc *SanityContext, n csi.NodeClient, vol VolumeGetter) (rsp *csi.NodeUnstageVolumeResponse) {
+	if isNodeStageSupported(n) {
+		By("cleaning up calling nodeunstage")
+		rsp, err := n.NodeUnstageVolume(
+			context.Background(),
+			&csi.NodeUnstageVolumeRequest{
+				VolumeId:          vol.GetVolume().GetVolumeId(),
+				StagingTargetPath: sc.StagingPath,
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rsp).NotTo(BeNil())
+	}
+	return
+}
+
+func maybeControllerExpandVolume(sc *SanityContext, c csi.ControllerClient, vol VolumeGetter) (rsp *csi.ControllerExpandVolumeResponse) {
+	if isControllerExpandVolumeSupported(c) {
+		By("calling controllerexpandvolume")
+		rsp, err := c.ControllerExpandVolume(context.Background(),
+			&csi.ControllerExpandVolumeRequest{
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: TestVolumeExpandSize(sc),
+				},
+				VolumeId: vol.GetVolume().GetVolumeId(),
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rsp).NotTo(BeNil())
+	}
+	return
+}
+
+func maybeGetVolumeStats(
+	c csi.NodeClient, vol VolumeGetter, targetPath string) (rsp *csi.NodeGetVolumeStatsResponse, err error) {
+	if isNodeVolumeStatsSupported(c) {
+		By("Get node volume stats")
+		rsp, err = c.NodeGetVolumeStats(
+			context.Background(),
+			&csi.NodeGetVolumeStatsRequest{
+				VolumeId:   vol.GetVolume().GetVolumeId(),
+				VolumePath: targetPath,
+			},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rsp.GetUsage()).ToNot(BeNil())
+	}
+	return
+}
+
+func maybeControllerPublishVolume(
+	sc *SanityContext, cl *Cleanup, c csi.ControllerClient, name string, vol *csi.CreateVolumeResponse,
+	nodeID string) (rsp *csi.ControllerPublishVolumeResponse) {
+	if isControllerPublishSupported(c) {
+		By("controller publishing volume")
+		rsp, err := c.ControllerPublishVolume(
+			context.Background(),
+			&csi.ControllerPublishVolumeRequest{
+				VolumeId: vol.GetVolume().GetVolumeId(),
+				NodeId:   nodeID,
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+				VolumeContext: vol.GetVolume().GetVolumeContext(),
+				Readonly:      false,
+				Secrets:       sc.Secrets.ControllerPublishVolumeSecret,
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		cl.RegisterVolume(name, VolumeInfo{VolumeID: vol.GetVolume().GetVolumeId(), NodeID: nodeID})
+		Expect(rsp).NotTo(BeNil())
+	}
+	return
+}
+
+func maybeControllerUnpublishVolume(sc *SanityContext, c csi.ControllerClient, vol VolumeGetter, nodeID string) (rsp *csi.ControllerUnpublishVolumeResponse) {
+	if isControllerPublishSupported(c) {
+		By("cleaning up calling controllerunpublishing")
+
+		rsp, err := c.ControllerUnpublishVolume(
+			context.Background(),
+			&csi.ControllerUnpublishVolumeRequest{
+				VolumeId: vol.GetVolume().GetVolumeId(),
+				NodeId:   nodeID,
+				Secrets:  sc.Secrets.ControllerUnpublishVolumeSecret,
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rsp).NotTo(BeNil())
+	}
+	return
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind test-case

**What this PR does / why we need it**:
This PR implements a node expand volume testcase for node servers that have the VolumeExpansionOnline capability enabled. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:
Since I use some new helper functions (like maybeNodeStageVolume), I'd like to know if this is appreciated. If so, I would refactor the other test cases to use these helper functions as well and move these functions into a dedicated source file.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added test for NodeExpandVolume (Online Expansion)
```
