### PR TITLE
Tolerate nil capabilities for plugins that don't provide CONTROLLER_SERVICE

### DIFF
--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -92,7 +92,7 @@ func isControllerCapabilitySupported(
 	return false
 }
 
-var _ = DescribeSanity("Controller Service", func(sc *SanityContext) {
+var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *SanityContext) {
 	var (
 		c csi.ControllerClient
 		n csi.NodeClient

--- a/pkg/sanity/identity.go
+++ b/pkg/sanity/identity.go
@@ -47,7 +47,6 @@ var _ = DescribeSanity("Identity Service", func(sc *SanityContext) {
 			Expect(res).NotTo(BeNil())
 
 			By("checking successful response")
-			Expect(res.GetCapabilities()).NotTo(BeNil())
 			for _, cap := range res.GetCapabilities() {
 				switch cap.GetType().(type) {
 				case *csi.PluginCapability_Service_:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: providing CONTROLLER_SERVICE is optional. Node tests should not fail if it's not provided. With these changes, it's possible to do
$ csi-sanity --csi.endpoint=./csi.sock -ginkgo.skip='\[Controller.Server\]'
to test a node-only plugin against node-specific tests

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
