### PR TITLE
ephemeral volumes

### DIFF
--- a/cmd/mock-driver/main.go
+++ b/cmd/mock-driver/main.go
@@ -36,6 +36,7 @@ func main() {
 	flag.BoolVar(&config.NodeExpansionRequired, "node-expand-required", false, "Enables NodeServiceCapability_RPC_EXPAND_VOLUME capacity.")
 	flag.BoolVar(&config.DisableControllerExpansion, "disable-controller-expansion", false, "Disables ControllerServiceCapability_RPC_EXPAND_VOLUME capability.")
 	flag.BoolVar(&config.DisableOnlineExpansion, "disable-online-expansion", false, "Disables online volume expansion capability.")
+	flag.BoolVar(&config.PermissiveTargetPath, "permissive-target-path", false, "Allows the CO to create PublishVolumeRequest.TargetPath, which violates the CSI spec.")
 	flag.Parse()
 
 	endpoint := os.Getenv("CSI_ENDPOINT")

--- a/mock/service/service.go
+++ b/mock/service/service.go
@@ -60,6 +60,7 @@ type Volume struct {
 	NodeID          string
 	ISStaged        bool
 	ISPublished     bool
+	ISEphemeral     bool
 	StageTargetPath string
 	TargetPath      string
 }

--- a/mock/service/service.go
+++ b/mock/service/service.go
@@ -33,6 +33,7 @@ type Config struct {
 	NodeExpansionRequired      bool
 	DisableControllerExpansion bool
 	DisableOnlineExpansion     bool
+	PermissiveTargetPath       bool
 }
 
 // Service is the CSI Mock service provider.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This enables testing of recent csi-mock with recent Kubernetes by allowing the Kubernetes tests to make the TargetPath existence check more permissive and the testing of ephemeral inline volumes in Kubernetes.

**Special notes for your reviewer**:

All of the "CSI Mock volume" tests (https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/csi_mock_volume.go#L59) still pass with this new driver.

**Does this PR introduce a user-facing change?**:
```release-note
csi-mock driver now supports relaxing the target path check (--permissive-target-path) and ephemeral inline volumes
```
