### PR TITLE
Pass ControllerExpandVolumeSecret info to the VolumeExpand CSI tests

### DIFF
--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -2097,6 +2097,7 @@ var _ = DescribeSanity("ExpandVolume [Controller Server]", func(sc *SanityContex
 			CapacityRange: &csi.CapacityRange{
 				RequiredBytes: TestVolumeExpandSize(sc),
 			},
+			Secrets: sc.Secrets.ControllerExpandVolumeSecret,
 		}
 		rsp, err := c.ControllerExpandVolume(context.Background(), expReq)
 		Expect(err).To(HaveOccurred())
@@ -2110,6 +2111,7 @@ var _ = DescribeSanity("ExpandVolume [Controller Server]", func(sc *SanityContex
 	It("should fail if no capacity range is given", func() {
 		expReq := &csi.ControllerExpandVolumeRequest{
 			VolumeId: "",
+			Secrets:  sc.Secrets.ControllerExpandVolumeSecret,
 		}
 		rsp, err := c.ControllerExpandVolume(context.Background(), expReq)
 		Expect(err).To(HaveOccurred())
@@ -2156,6 +2158,7 @@ var _ = DescribeSanity("ExpandVolume [Controller Server]", func(sc *SanityContex
 			CapacityRange: &csi.CapacityRange{
 				RequiredBytes: TestVolumeExpandSize(sc),
 			},
+			Secrets: sc.Secrets.ControllerExpandVolumeSecret,
 		}
 		rsp, err := c.ControllerExpandVolume(context.Background(), expReq)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -48,6 +48,7 @@ type CSISecrets struct {
 	NodePublishVolumeSecret                    map[string]string `yaml:"NodePublishVolumeSecret"`
 	CreateSnapshotSecret                       map[string]string `yaml:"CreateSnapshotSecret"`
 	DeleteSnapshotSecret                       map[string]string `yaml:"DeleteSnapshotSecret"`
+	ControllerExpandVolumeSecret               map[string]string `yaml:"ControllerExpandVolumeSecret"`
 }
 
 // Config provides the configuration for the sanity tests. It


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind bug

**What this PR does / why we need it**:
A few sanity tests (i.e, ControllerExpandVolume) failed with our CSI driver due to missing or empty secrets provided in the ‘ControllerExpandVolumeRequest’. This is required by the CSI driver to fetch/get the volume from the backend storage.
so, this PR implements the changes to include secrets in the ControllerExpandVolumeRequest.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #215

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
