### PR TITLE
sanity: fix nil pointer error for IDGen when using Ginkgo suite

### DIFF
--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -121,9 +121,10 @@ type Config struct {
 	// Timeout for the executed commands for path removal.
 	RemovePathCmdTimeout int
 
-	// IDGen is an optional interface for callers to provide a generator for
-	// valid Volume and Node IDs. Defaults to DefaultIDGenerator which generates
-	// generic string IDs
+	// IDGen is an optional interface for callers to provide a
+	// generator for valid Volume and Node IDs. If unset,
+	// it will be set to a DefaultIDGenerator instance when
+	// passing the config to Test or GinkgoTest.
 	IDGen IDGenerator
 }
 
@@ -143,6 +144,21 @@ type SanityContext struct {
 	StagingPath string
 }
 
+// newContext sets up sanity testing with a config supplied by the
+// user of the sanity package. Ownership of that config is shared
+// between the sanity package and the caller.
+func newContext(reqConfig *Config) *SanityContext {
+	// To avoid runtime if checks when using IDGen, a default
+	// is set here.
+	if reqConfig.IDGen == nil {
+		reqConfig.IDGen = &DefaultIDGenerator{}
+	}
+
+	return &SanityContext{
+		Config: reqConfig,
+	}
+}
+
 // Test will test the CSI driver at the specified address by
 // setting up a Ginkgo suite and running it.
 func Test(t *testing.T, reqConfig *Config) {
@@ -158,14 +174,7 @@ func Test(t *testing.T, reqConfig *Config) {
 		}
 	}
 
-	if reqConfig.IDGen == nil {
-		reqConfig.IDGen = &DefaultIDGenerator{}
-	}
-
-	sc := &SanityContext{
-		Config: reqConfig,
-	}
-
+	sc := newContext(reqConfig)
 	registerTestsInGinkgo(sc)
 	RegisterFailHandler(Fail)
 
@@ -180,11 +189,11 @@ func Test(t *testing.T, reqConfig *Config) {
 	}
 }
 
+// GinkoTest is another entry point for sanity testing: instead of directly
+// running tests like Test does, it merely registers the tests. This can
+// be used to embed sanity testing in a custom Ginkgo test suite.
 func GinkgoTest(reqConfig *Config) {
-	sc := &SanityContext{
-		Config: reqConfig,
-	}
-
+	sc := newContext(reqConfig)
 	registerTestsInGinkgo(sc)
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When adding IDGen, only one of the two code paths that trigger testing
was updated such that it sets a default ID generator when the config
doesn't already have one. GinkgoTest was not updated.

As a result, existing E2E suites which use GinkgoTest and don't set the
new field crash at runtime with a nil pointer error when updated to
csi-test 2.2.0.

Updating the instance provided by the caller is also a bit
questionable because it is an undocumented side effect. It's cleaner
to treat the struct as read-only and implement the fallback in an
accessor function.

**Special notes for your reviewer**:

We should create a 2.2.1 with this fix...

**Does this PR introduce a user-facing change?**:
```release-note
fix nil pointer error when Config.IDGen is not set
```
