### PR TITLE
sanity: check the error after removing MountTargetLocation

### DIFF
--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -291,8 +291,13 @@ func (sc *TestContext) Setup() {
 // allocated by Setup.
 func (sc *TestContext) Teardown() {
 	// Delete the created paths if any.
-	removeMountTargetLocation(sc.TargetPath, sc.Config.RemoveTargetPathCmd, sc.Config.RemoveTargetPath, sc.Config.RemovePathCmdTimeout)
-	removeMountTargetLocation(sc.StagingPath, sc.Config.RemoveStagingPathCmd, sc.Config.RemoveStagingPath, sc.Config.RemovePathCmdTimeout)
+	err1 := removeMountTargetLocation(sc.TargetPath, sc.Config.RemoveTargetPathCmd, sc.Config.RemoveTargetPath, sc.Config.RemovePathCmdTimeout)
+	err2 := removeMountTargetLocation(sc.StagingPath, sc.Config.RemoveStagingPathCmd, sc.Config.RemoveStagingPath, sc.Config.RemovePathCmdTimeout)
+	failures := InterceptGomegaFailures(func() {
+		Expect(err1).NotTo(HaveOccurred(), "failed to delete target directory %s", sc.TargetPath)
+		Expect(err2).NotTo(HaveOccurred(), "failed to delete staging directory %s", sc.StagingPath)
+	})
+	Expect(failures).To(BeEmpty())
 
 	// We intentionally do not close the connection to the CSI
 	// driver here because the large amount of connection attempts

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -903,7 +903,7 @@ EOF
                      -csi.junitfile "${ARTIFACTS}/junit_sanity.xml" \
                      -csi.endpoint "dns:///$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' csi-prow-control-plane):$(kubectl get "services/${CSI_PROW_SANITY_SERVICE}" -o "jsonpath={..nodePort}")" \
                      -csi.stagingdir "/tmp/staging" \
-                     -csi.mountdir "/tmp/mount" \
+                     -csi.mountdir "/mnt/mount" \
                      -csi.createstagingpathcmd "${CSI_PROW_WORK}/mkdir_in_pod.sh" \
                      -csi.createmountpathcmd "${CSI_PROW_WORK}/mkdir_in_pod.sh" \
                      -csi.removestagingpathcmd "${CSI_PROW_WORK}/rmdir_in_pod.sh" \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When developing a CSI driver, I used `csi-sanity` to test it. The test `should work` in `Node Service` worked well for the first time. But an error appeared for the second time. After reading the source code of sanity tests and debugging for a while, I found that I should delete the target directory `/tmp/csi-mount/target` in `NodeUnpublishVolume`. 
I always thought all subdirectories in `/tmp/csi-mount` would be deleted recursively by sanity test. Because there is no error to remind me. 
So this is the reason why I think we need to check the removing operation. With checking, it will help the developer to locate the error and improve development efficiency.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
check the error after removing MountTargetLocation
```
