### PR TITLE
sanity: Disable ListVolumes pagination test

### DIFF
--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -259,11 +259,18 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *Sanity
 			Expect(len(vols.GetEntries())).To(Equal(totalVols))
 		})
 
-		It("pagination should detect volumes added between pages and accept tokens when the last volume from a page is deleted", func() {
+		// Disabling this below case as it is fragile and results are inconsistent
+		// when no of volumes are different. The test might fail on a driver
+		// which implements the pagination based on index just by altering
+		// minVolCount := 4 and maxEntries := 3
+		// Related discussion links:
+		//  https://github.com/intel/pmem-csi/pull/424#issuecomment-540499938
+		//  https://github.com/kubernetes-csi/csi-test/issues/223
+		XIt("pagination should detect volumes added between pages and accept tokens when the last volume from a page is deleted", func() {
 			// minVolCount is the minimum number of volumes expected to exist,
 			// based on which paginated volume listing is performed.
 			minVolCount := 3
-			// maxEntried is the maximum entries in list volume request.
+			// maxEntries is the maximum entries in list volume request.
 			maxEntries := 2
 			// existing_vols to keep a record of the volumes that should exist
 			existing_vols := map[string]bool{}
@@ -358,6 +365,8 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *Sanity
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vol).NotTo(BeNil())
 			Expect(vol.Volume).NotTo(BeNil())
+			// Register the volume so it's automatically cleaned
+			cl.RegisterVolume(vol.Volume.VolumeId, VolumeInfo{VolumeID: vol.Volume.VolumeId})
 			existing_vols[vol.Volume.VolumeId] = true
 
 			vols, err = c.ListVolumes(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Volume created by testcase is not adding to cleanup list, hence it results in
volume leaking. This change fixes this issue.

The side effect of this testcase fix discovered a minor issue in mock driver implementation.
Which was hidden due to the leftover volume created by above testcase.


<!-- **Special notes for your reviewer**: -->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
