### PR TITLE
Fix go module requirements for semantic versioning

### DIFF
--- a/cmd/csi-sanity/sanity_test.go
+++ b/cmd/csi-sanity/sanity_test.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/kubernetes-csi/csi-test/pkg/sanity"
+	"github.com/kubernetes-csi/csi-test/v2/pkg/sanity"
 )
 
 const (

--- a/cmd/csi-sanity/sanity_test.go
+++ b/cmd/csi-sanity/sanity_test.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/kubernetes-csi/csi-test/v2/pkg/sanity"
+	"github.com/kubernetes-csi/csi-test/v3/pkg/sanity"
 )
 
 const (

--- a/cmd/mock-driver/main.go
+++ b/cmd/mock-driver/main.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/kubernetes-csi/csi-test/driver"
-	"github.com/kubernetes-csi/csi-test/mock/service"
+	"github.com/kubernetes-csi/csi-test/v2/driver"
+	"github.com/kubernetes-csi/csi-test/v2/mock/service"
 )
 
 func main() {

--- a/cmd/mock-driver/main.go
+++ b/cmd/mock-driver/main.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/kubernetes-csi/csi-test/v2/driver"
-	"github.com/kubernetes-csi/csi-test/v2/mock/service"
+	"github.com/kubernetes-csi/csi-test/v3/driver"
+	"github.com/kubernetes-csi/csi-test/v3/mock/service"
 )
 
 func main() {

--- a/driver/mock.go
+++ b/driver/mock.go
@@ -19,7 +19,7 @@ package driver
 import (
 	"net"
 
-	"github.com/kubernetes-csi/csi-test/v2/utils"
+	"github.com/kubernetes-csi/csi-test/v3/utils"
 	"google.golang.org/grpc"
 )
 

--- a/driver/mock.go
+++ b/driver/mock.go
@@ -19,7 +19,7 @@ package driver
 import (
 	"net"
 
-	"github.com/kubernetes-csi/csi-test/utils"
+	"github.com/kubernetes-csi/csi-test/v2/utils"
 	"google.golang.org/grpc"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kubernetes-csi/csi-test/v2
+module github.com/kubernetes-csi/csi-test/v3
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kubernetes-csi/csi-test
+module github.com/kubernetes-csi/csi-test/v2
 
 go 1.12
 

--- a/mock/service/service.go
+++ b/mock/service/service.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/kubernetes-csi/csi-test/mock/cache"
+	"github.com/kubernetes-csi/csi-test/v2/mock/cache"
 	"golang.org/x/net/context"
 
 	"github.com/golang/protobuf/ptypes"

--- a/mock/service/service.go
+++ b/mock/service/service.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/kubernetes-csi/csi-test/v2/mock/cache"
+	"github.com/kubernetes-csi/csi-test/v3/mock/cache"
 	"golang.org/x/net/context"
 
 	"github.com/golang/protobuf/ptypes"

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kubernetes-csi/csi-test/utils"
+	"github.com/kubernetes-csi/csi-test/v2/utils"
 	yaml "gopkg.in/yaml.v2"
 
 	"google.golang.org/grpc"

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kubernetes-csi/csi-test/v2/utils"
+	"github.com/kubernetes-csi/csi-test/v3/utils"
 	yaml "gopkg.in/yaml.v2"
 
 	"google.golang.org/grpc"

--- a/test/co_test.go
+++ b/test/co_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/proto"
-	mock_driver "github.com/kubernetes-csi/csi-test/driver"
-	mock_utils "github.com/kubernetes-csi/csi-test/utils"
+	mock_driver "github.com/kubernetes-csi/csi-test/v2/driver"
+	mock_utils "github.com/kubernetes-csi/csi-test/v2/utils"
 )
 
 func TestPluginInfoResponse(t *testing.T) {

--- a/test/co_test.go
+++ b/test/co_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/proto"
-	mock_driver "github.com/kubernetes-csi/csi-test/v2/driver"
-	mock_utils "github.com/kubernetes-csi/csi-test/v2/utils"
+	mock_driver "github.com/kubernetes-csi/csi-test/v3/driver"
+	mock_utils "github.com/kubernetes-csi/csi-test/v3/utils"
 )
 
 func TestPluginInfoResponse(t *testing.T) {

--- a/test/driver_test.go
+++ b/test/driver_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/kubernetes-csi/csi-test/v2/utils"
+	"github.com/kubernetes-csi/csi-test/v3/utils"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 )

--- a/test/driver_test.go
+++ b/test/driver_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/kubernetes-csi/csi-test/utils"
+	"github.com/kubernetes-csi/csi-test/v2/utils"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 )

--- a/v3/README.md
+++ b/v3/README.md
@@ -1,0 +1,18 @@
+This directory mirrors the source code via symlinks.
+This makes it possible to vendor v3.x releases of
+csi-test with `dep` versions that do not support
+semantic imports. Support for that is currently
+[pending in dep](https://github.com/golang/dep/pull/1963).
+
+If users of dep have enabled pruning, they must disable if
+for csi-test in their Gopk.toml, like this:
+
+```toml
+[prune]
+  go-tests = true
+  unused-packages = true
+
+  [[prune.project]]
+    name = "github.com/kubernetes-csi/csi-test"
+    unused-packages = false
+```

--- a/v3/driver/driver-controller.go
+++ b/v3/driver/driver-controller.go
@@ -1,0 +1,1 @@
+../../driver/driver-controller.go

--- a/v3/driver/driver-node.go
+++ b/v3/driver/driver-node.go
@@ -1,0 +1,1 @@
+../../driver/driver-node.go

--- a/v3/driver/driver.go
+++ b/v3/driver/driver.go
@@ -1,0 +1,1 @@
+../../driver/driver.go

--- a/v3/driver/driver.mock.go
+++ b/v3/driver/driver.mock.go
@@ -1,0 +1,1 @@
+../../driver/driver.mock.go

--- a/v3/driver/mock.go
+++ b/v3/driver/mock.go
@@ -1,0 +1,1 @@
+../../driver/mock.go

--- a/v3/mock/cache/SnapshotCache.go
+++ b/v3/mock/cache/SnapshotCache.go
@@ -1,0 +1,1 @@
+../../../mock/cache/SnapshotCache.go

--- a/v3/mock/service/controller.go
+++ b/v3/mock/service/controller.go
@@ -1,0 +1,1 @@
+../../../mock/service/controller.go

--- a/v3/mock/service/identity.go
+++ b/v3/mock/service/identity.go
@@ -1,0 +1,1 @@
+../../../mock/service/identity.go

--- a/v3/mock/service/node.go
+++ b/v3/mock/service/node.go
@@ -1,0 +1,1 @@
+../../../mock/service/node.go

--- a/v3/mock/service/service.go
+++ b/v3/mock/service/service.go
@@ -1,0 +1,1 @@
+../../../mock/service/service.go

--- a/v3/pkg/sanity/cleanup.go
+++ b/v3/pkg/sanity/cleanup.go
@@ -1,0 +1,1 @@
+../../../pkg/sanity/cleanup.go

--- a/v3/pkg/sanity/controller.go
+++ b/v3/pkg/sanity/controller.go
@@ -1,0 +1,1 @@
+../../../pkg/sanity/controller.go

--- a/v3/pkg/sanity/identity.go
+++ b/v3/pkg/sanity/identity.go
@@ -1,0 +1,1 @@
+../../../pkg/sanity/identity.go

--- a/v3/pkg/sanity/node.go
+++ b/v3/pkg/sanity/node.go
@@ -1,0 +1,1 @@
+../../../pkg/sanity/node.go

--- a/v3/pkg/sanity/sanity.go
+++ b/v3/pkg/sanity/sanity.go
@@ -1,0 +1,1 @@
+../../../pkg/sanity/sanity.go

--- a/v3/pkg/sanity/tests.go
+++ b/v3/pkg/sanity/tests.go
@@ -1,0 +1,1 @@
+../../../pkg/sanity/tests.go

--- a/v3/pkg/sanity/util.go
+++ b/v3/pkg/sanity/util.go
@@ -1,0 +1,1 @@
+../../../pkg/sanity/util.go

--- a/v3/utils/grpcutil.go
+++ b/v3/utils/grpcutil.go
@@ -1,0 +1,1 @@
+../../utils/grpcutil.go

--- a/v3/utils/safegoroutinetester.go
+++ b/v3/utils/safegoroutinetester.go
@@ -1,0 +1,1 @@
+../../utils/safegoroutinetester.go


### PR DESCRIPTION
As stated in this post:
https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher
modules that released a version higher than 1 need to put the version
into the package path.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
When 2.3.0 introduced go modules, the package paths where not updated. Therefore
this module cannot be imported as version 2.3.0 since go mod will complain: 
```console
go.mod:12: require github.com/kubernetes-csi/csi-test: version "v2.3.0" invalid: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v2
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #231 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update package path to v3. Vendoring with dep depends on https://github.com/golang/dep/pull/1963 or the workaround described in v3/README.md.
```
