### PR TITLE
csi-sanity binary

### DIFF
--- a/cmd/csi-sanity/Makefile
+++ b/cmd/csi-sanity/Makefile
@@ -22,8 +22,9 @@ PACKAGE :=$(DIR)/dist/$(APP_NAME)-$(RELEASEVER).$(GOOS).$(ARCH).tar.gz
 
 all: $(APP_NAME)
 
-$(APP_NAME): Makefile sanity_test.go
-	go test $(LDFLAGS) -c -o $(APP_NAME)
+.PHONY: $(APP_NAME)
+$(APP_NAME): Makefile
+	go build $(LDFLAGS) -o $(APP_NAME)
 
 install: $(APP_NAME)
 	cp $(APP_NAME) $(GOPATH)/bin

--- a/cmd/csi-sanity/main.go
+++ b/cmd/csi-sanity/main.go
@@ -13,13 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package sanity
+package main
 
 import (
 	"flag"
 	"fmt"
 	"os"
-	"testing"
 	"time"
 
 	"github.com/kubernetes-csi/csi-test/v3/pkg/sanity"
@@ -31,7 +30,6 @@ const (
 
 var (
 	VERSION = "(dev)"
-	config  = sanity.NewTestConfig()
 )
 
 func stringVar(p *string, name string, usage string) {
@@ -54,8 +52,19 @@ func durationVar(p *time.Duration, name string, usage string) {
 	flag.DurationVar(p, prefix+name, *p, usage)
 }
 
-func TestMain(m *testing.M) {
+type testing struct {
+	result int
+}
+
+func (t *testing) Fail() {
+	t.result = 1
+}
+
+func main() {
 	version := flag.Bool("version", false, "print version of this program")
+
+	// Get configuration with defaults.
+	config := sanity.NewTestConfig()
 
 	// Support overriding the default configuration via flags.
 	stringVar(&config.Address, "endpoint", "CSI endpoint")
@@ -85,9 +94,8 @@ func TestMain(m *testing.M) {
 		fmt.Printf("--%sendpoint must be provided with an CSI endpoint\n", prefix)
 		os.Exit(1)
 	}
-	os.Exit(m.Run())
-}
 
-func TestSanity(t *testing.T) {
-	sanity.Test(t, config)
+	t := testing{}
+	sanity.Test(&t, config)
+	os.Exit(t.result)
 }

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/kubernetes-csi/csi-test/v3/utils"
@@ -189,7 +188,7 @@ func newTestContext(config *TestConfig) *TestContext {
 
 // Test will test the CSI driver at the specified address by
 // setting up a Ginkgo suite and running it.
-func Test(t *testing.T, config TestConfig) {
+func Test(t GinkgoTestingT, config TestConfig) {
 	sc := GinkgoTest(&config)
 	RegisterFailHandler(Fail)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This enables "go get github.com/kubernetes-csi/csi-test/cmd/csi-sanity" and gets rid of useless "-test.*" parameters.

**Special notes for your reviewer**:

Builds on top of PR #233 which needs to be merged first.

**Does this PR introduce a user-facing change?**:
```release-note
`go get github.com/kubernetes-csi/csi-test/cmd/csi-sanity` now works
```
