### PR TITLE
keepalive API

### DIFF
--- a/driver/mock.go
+++ b/driver/mock.go
@@ -75,7 +75,7 @@ func (m *MockCSIDriver) Nexus() (*grpc.ClientConn, error) {
 	}
 
 	// Create a client connection
-	m.conn, err = utils.Connect(m.Address())
+	m.conn, err = utils.Connect(m.Address(), grpc.WithInsecure())
 	if err != nil {
 		return nil, err
 	}

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -4,6 +4,10 @@ TESTARGS=$@
 UDS="/tmp/e2e-csi-sanity.sock"
 UDS_NODE="/tmp/e2e-csi-sanity-node.sock"
 UDS_CONTROLLER="/tmp/e2e-csi-sanity-ctrl.sock"
+# Protocol specified as for net.Listen...
+TCP_SERVER="tcp://localhost:7654"
+# ... and slightly differently for gRPC.
+TCP_CLIENT="dns:///localhost:7654"
 CSI_ENDPOINTS="$CSI_ENDPOINTS ${UDS}"
 CSI_MOCK_VERSION="master"
 
@@ -108,6 +112,7 @@ cd cmd/csi-sanity
   make clean install || exit 1
 cd ../..
 
+runTest "${TCP_SERVER}" "${TCP_CLIENT}" &&
 runTest "${UDS}" "${UDS}" &&
 runTestWithCreds "${UDS}" "${UDS}" &&
 runTestAPI "${UDS}" &&

--- a/test/driver_test.go
+++ b/test/driver_test.go
@@ -106,7 +106,7 @@ func TestSimpleDriver(t *testing.T) {
 	defer s.Stop()
 
 	// Setup a connection to the driver
-	conn, err := utils.Connect(s.Address())
+	conn, err := utils.Connect(s.Address(), grpc.WithInsecure())
 	if err != nil {
 		t.Errorf("Error: %s", err.Error())
 	}

--- a/utils/grpcutil.go
+++ b/utils/grpcutil.go
@@ -25,14 +25,10 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/keepalive"
 )
 
 // Connect address by grpc
-func Connect(address string) (*grpc.ClientConn, error) {
-	dialOptions := []grpc.DialOption{
-		grpc.WithInsecure(),
-	}
+func Connect(address string, dialOptions ...grpc.DialOption) (*grpc.ClientConn, error) {
 	u, err := url.Parse(address)
 	if err == nil && (!u.IsAbs() || u.Scheme == "unix") {
 		dialOptions = append(dialOptions,
@@ -41,11 +37,6 @@ func Connect(address string) (*grpc.ClientConn, error) {
 					return net.DialTimeout("unix", u.Path, timeout)
 				}))
 	}
-	// This is necessary when connecting via TCP and does not hurt
-	// when using Unix domain sockets. It ensures that gRPC detects a dead connection
-	// in a timely manner.
-	dialOptions = append(dialOptions,
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{PermitWithoutStream: true}))
 
 	conn, err := grpc.Dial(address, dialOptions...)
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -97,7 +97,6 @@ google.golang.org/grpc/codes
 google.golang.org/grpc/reflection
 google.golang.org/grpc/status
 google.golang.org/grpc/connectivity
-google.golang.org/grpc/keepalive
 google.golang.org/grpc/balancer
 google.golang.org/grpc/balancer/roundrobin
 google.golang.org/grpc/credentials
@@ -112,6 +111,7 @@ google.golang.org/grpc/internal/envconfig
 google.golang.org/grpc/internal/grpcrand
 google.golang.org/grpc/internal/grpcsync
 google.golang.org/grpc/internal/transport
+google.golang.org/grpc/keepalive
 google.golang.org/grpc/metadata
 google.golang.org/grpc/naming
 google.golang.org/grpc/peer


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:

Enabling gRPC keepalive breaks connections if the CSI driver isn't prepared for it. When testing this is was useful to also support TCP in the mock driver.

**Which issue(s) this PR fixes**:
Fixes #238 

**Special notes for your reviewer**:

Depends on PR #233 

**Does this PR introduce a user-facing change?**:
```release-note
gRPC keepalive is no longer enabled by default and must be added to dial options in `TestConfig` if needed
```
