### PR TITLE
Update pkg/sanity Go driver usage README instructions

### DIFF
--- a/pkg/sanity/README.md
+++ b/pkg/sanity/README.md
@@ -15,12 +15,9 @@ Golang `TestXXX` functions. For example:
 func TestMyDriver(t *testing.T) {
 	// Setup the full driver and its environment
 	... setup driver ...
-	config := &sanity.Config{
-		TargetPath:     ...
-		StagingPath:    ...
-		Address:        endpoint,
-	}
-
+	config := sanity.NewTestConfig()
+	// Set configuration options as needed
+	cfg.Address = endpoint
 
 	// Now call the test suite
 	sanity.Test(t, config)


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
The change updates the `pkg/sanity` Go driver usage instructions in the README.

It seems like the approach to putting together a test configuration has changed since it was previously written down.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig storage