### PR TITLE
Tests for raw block volumes are added

### DIFF
--- a/cmd/csi-sanity/main.go
+++ b/cmd/csi-sanity/main.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/kubernetes-csi/csi-test/v3/pkg/sanity"
@@ -78,6 +79,7 @@ func main() {
 	stringVar(&config.RemoveStagingPathCmd, "removestagingpathcmd", "Command to run for staging path removal")
 	durationVar(&config.RemovePathCmdTimeout, "removepathcmdtimeout", "Timeout for the commands to remove target and staging paths, in seconds")
 	stringVar(&config.SecretsFile, "secrets", "CSI secrets file")
+	stringVar(&config.TestVolumeAccessType, "testvolumeaccesstype", "Volume capability access type, valid values are mount or block")
 	int64Var(&config.TestVolumeSize, "testvolumesize", "Base volume size used for provisioned volumes")
 	int64Var(&config.TestVolumeExpandSize, "testvolumeexpandsize", "Target size for expanded volumes")
 	stringVar(&config.TestVolumeParametersFile, "testvolumeparameters", "YAML file of volume parameters for provisioned volumes")
@@ -92,6 +94,10 @@ func main() {
 	}
 	if config.Address == "" {
 		fmt.Printf("--%sendpoint must be provided with an CSI endpoint\n", prefix)
+		os.Exit(1)
+	}
+	if at := strings.TrimSpace(strings.ToLower(config.TestVolumeAccessType)); !(at == "mount" || at == "block") {
+		fmt.Printf("--%stestvolumeaccesstype valid values are mount or block\n", prefix)
 		os.Exit(1)
 	}
 

--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -42,6 +43,22 @@ const (
 
 func TestVolumeSize(sc *TestContext) int64 {
 	return sc.Config.TestVolumeSize
+}
+
+func TestVolumeCapabilityWithAccessType(sc *TestContext, m csi.VolumeCapability_AccessMode_Mode) *csi.VolumeCapability {
+	vc := &csi.VolumeCapability{
+		AccessMode: &csi.VolumeCapability_AccessMode{Mode: m},
+		AccessType: &csi.VolumeCapability_Mount{
+			Mount: &csi.VolumeCapability_MountVolume{},
+		},
+	}
+	if at := strings.TrimSpace(strings.ToLower(sc.Config.TestVolumeAccessType)); at == "block" {
+		vc.AccessType = &csi.VolumeCapability_Block{
+			Block: &csi.VolumeCapability_BlockVolume{},
+		}
+	}
+
+	return vc
 }
 
 func TestVolumeExpandSize(sc *TestContext) int64 {
@@ -207,14 +224,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 			req := &csi.CreateVolumeRequest{
 				Name: name,
 				VolumeCapabilities: []*csi.VolumeCapability{
-					{
-						AccessType: &csi.VolumeCapability_Mount{
-							Mount: &csi.VolumeCapability_MountVolume{},
-						},
-						AccessMode: &csi.VolumeCapability_AccessMode{
-							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-						},
-					},
+					TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 				},
 				Secrets: sc.Secrets.CreateVolumeSecret,
 			}
@@ -291,14 +301,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 					req := &csi.CreateVolumeRequest{
 						Name: name,
 						VolumeCapabilities: []*csi.VolumeCapability{
-							{
-								AccessType: &csi.VolumeCapability_Mount{
-									Mount: &csi.VolumeCapability_MountVolume{},
-								},
-								AccessMode: &csi.VolumeCapability_AccessMode{
-									Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-								},
-							},
+							TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 						},
 						Secrets: sc.Secrets.CreateVolumeSecret,
 					}
@@ -343,14 +346,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 			req := &csi.CreateVolumeRequest{
 				Name: "new-addition",
 				VolumeCapabilities: []*csi.VolumeCapability{
-					{
-						AccessType: &csi.VolumeCapability_Mount{
-							Mount: &csi.VolumeCapability_MountVolume{},
-						},
-						AccessMode: &csi.VolumeCapability_AccessMode{
-							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-						},
-					},
+					TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 				},
 				Secrets: sc.Secrets.CreateVolumeSecret,
 			}
@@ -430,14 +426,10 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				&csi.CreateVolumeRequest{
 					Name: name,
 					VolumeCapabilities: []*csi.VolumeCapability{
-						{
-							AccessType: &csi.VolumeCapability_Mount{
-								Mount: &csi.VolumeCapability_MountVolume{},
-							},
-							AccessMode: &csi.VolumeCapability_AccessMode{
-								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-							},
-						},
+						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+					},
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: TestVolumeSize(sc),
 					},
 					Secrets:    sc.Secrets.CreateVolumeSecret,
 					Parameters: sc.Config.TestVolumeParameters,
@@ -472,14 +464,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				&csi.CreateVolumeRequest{
 					Name: name,
 					VolumeCapabilities: []*csi.VolumeCapability{
-						{
-							AccessType: &csi.VolumeCapability_Mount{
-								Mount: &csi.VolumeCapability_MountVolume{},
-							},
-							AccessMode: &csi.VolumeCapability_AccessMode{
-								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-							},
-						},
+						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					},
 					CapacityRange: &csi.CapacityRange{
 						RequiredBytes: TestVolumeSize(sc),
@@ -522,14 +507,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				&csi.CreateVolumeRequest{
 					Name: name,
 					VolumeCapabilities: []*csi.VolumeCapability{
-						{
-							AccessType: &csi.VolumeCapability_Mount{
-								Mount: &csi.VolumeCapability_MountVolume{},
-							},
-							AccessMode: &csi.VolumeCapability_AccessMode{
-								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-							},
-						},
+						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					},
 					CapacityRange: &csi.CapacityRange{
 						RequiredBytes: size,
@@ -550,14 +528,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				&csi.CreateVolumeRequest{
 					Name: name,
 					VolumeCapabilities: []*csi.VolumeCapability{
-						{
-							AccessType: &csi.VolumeCapability_Mount{
-								Mount: &csi.VolumeCapability_MountVolume{},
-							},
-							AccessMode: &csi.VolumeCapability_AccessMode{
-								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-							},
-						},
+						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					},
 					CapacityRange: &csi.CapacityRange{
 						RequiredBytes: size,
@@ -596,14 +567,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				&csi.CreateVolumeRequest{
 					Name: name,
 					VolumeCapabilities: []*csi.VolumeCapability{
-						{
-							AccessType: &csi.VolumeCapability_Mount{
-								Mount: &csi.VolumeCapability_MountVolume{},
-							},
-							AccessMode: &csi.VolumeCapability_AccessMode{
-								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-							},
-						},
+						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					},
 					CapacityRange: &csi.CapacityRange{
 						RequiredBytes: size1,
@@ -625,14 +589,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				&csi.CreateVolumeRequest{
 					Name: name,
 					VolumeCapabilities: []*csi.VolumeCapability{
-						{
-							AccessType: &csi.VolumeCapability_Mount{
-								Mount: &csi.VolumeCapability_MountVolume{},
-							},
-							AccessMode: &csi.VolumeCapability_AccessMode{
-								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-							},
-						},
+						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					},
 					CapacityRange: &csi.CapacityRange{
 						RequiredBytes: size2,
@@ -675,14 +632,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				&csi.CreateVolumeRequest{
 					Name: name,
 					VolumeCapabilities: []*csi.VolumeCapability{
-						{
-							AccessType: &csi.VolumeCapability_Mount{
-								Mount: &csi.VolumeCapability_MountVolume{},
-							},
-							AccessMode: &csi.VolumeCapability_AccessMode{
-								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-							},
-						},
+						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					},
 					CapacityRange: &csi.CapacityRange{
 						RequiredBytes: size,
@@ -884,14 +834,10 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				&csi.CreateVolumeRequest{
 					Name: name,
 					VolumeCapabilities: []*csi.VolumeCapability{
-						{
-							AccessType: &csi.VolumeCapability_Mount{
-								Mount: &csi.VolumeCapability_MountVolume{},
-							},
-							AccessMode: &csi.VolumeCapability_AccessMode{
-								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-							},
-						},
+						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+					},
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: TestVolumeSize(sc),
 					},
 					Secrets:    sc.Secrets.CreateVolumeSecret,
 					Parameters: sc.Config.TestVolumeParameters,
@@ -944,14 +890,10 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				&csi.CreateVolumeRequest{
 					Name: name,
 					VolumeCapabilities: []*csi.VolumeCapability{
-						{
-							AccessType: &csi.VolumeCapability_Mount{
-								Mount: &csi.VolumeCapability_MountVolume{},
-							},
-							AccessMode: &csi.VolumeCapability_AccessMode{
-								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-							},
-						},
+						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+					},
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: TestVolumeSize(sc),
 					},
 					Secrets:    sc.Secrets.CreateVolumeSecret,
 					Parameters: sc.Config.TestVolumeParameters,
@@ -966,8 +908,9 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 			_, err = c.ValidateVolumeCapabilities(
 				context.Background(),
 				&csi.ValidateVolumeCapabilitiesRequest{
-					VolumeId: vol.GetVolume().GetVolumeId(),
-					Secrets:  sc.Secrets.ControllerValidateVolumeCapabilitiesSecret,
+					VolumeId:           vol.GetVolume().GetVolumeId(),
+					VolumeCapabilities: nil,
+					Secrets:            sc.Secrets.ControllerValidateVolumeCapabilitiesSecret,
 				})
 			Expect(err).To(HaveOccurred())
 
@@ -999,14 +942,10 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				&csi.CreateVolumeRequest{
 					Name: name,
 					VolumeCapabilities: []*csi.VolumeCapability{
-						{
-							AccessType: &csi.VolumeCapability_Mount{
-								Mount: &csi.VolumeCapability_MountVolume{},
-							},
-							AccessMode: &csi.VolumeCapability_AccessMode{
-								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-							},
-						},
+						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+					},
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: TestVolumeSize(sc),
 					},
 					Secrets:    sc.Secrets.CreateVolumeSecret,
 					Parameters: sc.Config.TestVolumeParameters,
@@ -1025,14 +964,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				&csi.ValidateVolumeCapabilitiesRequest{
 					VolumeId: vol.GetVolume().GetVolumeId(),
 					VolumeCapabilities: []*csi.VolumeCapability{
-						{
-							AccessType: &csi.VolumeCapability_Mount{
-								Mount: &csi.VolumeCapability_MountVolume{},
-							},
-							AccessMode: &csi.VolumeCapability_AccessMode{
-								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-							},
-						},
+						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					},
 					Secrets: sc.Secrets.ControllerValidateVolumeCapabilitiesSecret,
 				})
@@ -1065,14 +997,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				&csi.ValidateVolumeCapabilitiesRequest{
 					VolumeId: sc.Config.IDGen.GenerateUniqueValidVolumeID(),
 					VolumeCapabilities: []*csi.VolumeCapability{
-						{
-							AccessType: &csi.VolumeCapability_Mount{
-								Mount: &csi.VolumeCapability_MountVolume{},
-							},
-							AccessMode: &csi.VolumeCapability_AccessMode{
-								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-							},
-						},
+						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					},
 					Secrets: sc.Secrets.ControllerValidateVolumeCapabilitiesSecret,
 				},
@@ -1169,14 +1094,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				&csi.CreateVolumeRequest{
 					Name: name,
 					VolumeCapabilities: []*csi.VolumeCapability{
-						{
-							AccessType: &csi.VolumeCapability_Mount{
-								Mount: &csi.VolumeCapability_MountVolume{},
-							},
-							AccessMode: &csi.VolumeCapability_AccessMode{
-								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-							},
-						},
+						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					},
 					Secrets:                   sc.Secrets.CreateVolumeSecret,
 					Parameters:                sc.Config.TestVolumeParameters,
@@ -1195,18 +1113,11 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 			conpubvol, err := c.ControllerPublishVolume(
 				context.Background(),
 				&csi.ControllerPublishVolumeRequest{
-					VolumeId: vol.GetVolume().GetVolumeId(),
-					NodeId:   ni.GetNodeId(),
-					VolumeCapability: &csi.VolumeCapability{
-						AccessType: &csi.VolumeCapability_Mount{
-							Mount: &csi.VolumeCapability_MountVolume{},
-						},
-						AccessMode: &csi.VolumeCapability_AccessMode{
-							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-						},
-					},
-					Readonly: false,
-					Secrets:  sc.Secrets.ControllerPublishVolumeSecret,
+					VolumeId:         vol.GetVolume().GetVolumeId(),
+					NodeId:           ni.GetNodeId(),
+					VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+					Readonly:         false,
+					Secrets:          sc.Secrets.ControllerPublishVolumeSecret,
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -1289,18 +1200,11 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 			conpubvol, err := c.ControllerPublishVolume(
 				context.Background(),
 				&csi.ControllerPublishVolumeRequest{
-					VolumeId: sc.Config.IDGen.GenerateUniqueValidVolumeID(),
-					NodeId:   sc.Config.IDGen.GenerateUniqueValidNodeID(),
-					VolumeCapability: &csi.VolumeCapability{
-						AccessType: &csi.VolumeCapability_Mount{
-							Mount: &csi.VolumeCapability_MountVolume{},
-						},
-						AccessMode: &csi.VolumeCapability_AccessMode{
-							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-						},
-					},
-					Readonly: false,
-					Secrets:  sc.Secrets.ControllerPublishVolumeSecret,
+					VolumeId:         sc.Config.IDGen.GenerateUniqueValidVolumeID(),
+					NodeId:           sc.Config.IDGen.GenerateUniqueValidNodeID(),
+					VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+					Readonly:         false,
+					Secrets:          sc.Secrets.ControllerPublishVolumeSecret,
 				},
 			)
 			Expect(err).To(HaveOccurred())
@@ -1322,14 +1226,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				&csi.CreateVolumeRequest{
 					Name: name,
 					VolumeCapabilities: []*csi.VolumeCapability{
-						{
-							AccessType: &csi.VolumeCapability_Mount{
-								Mount: &csi.VolumeCapability_MountVolume{},
-							},
-							AccessMode: &csi.VolumeCapability_AccessMode{
-								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-							},
-						},
+						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					},
 					Secrets:    sc.Secrets.CreateVolumeSecret,
 					Parameters: sc.Config.TestVolumeParameters,
@@ -1347,18 +1244,11 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 			conpubvol, err := c.ControllerPublishVolume(
 				context.Background(),
 				&csi.ControllerPublishVolumeRequest{
-					VolumeId: vol.GetVolume().GetVolumeId(),
-					NodeId:   sc.Config.IDGen.GenerateUniqueValidNodeID(),
-					VolumeCapability: &csi.VolumeCapability{
-						AccessType: &csi.VolumeCapability_Mount{
-							Mount: &csi.VolumeCapability_MountVolume{},
-						},
-						AccessMode: &csi.VolumeCapability_AccessMode{
-							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-						},
-					},
-					Readonly: false,
-					Secrets:  sc.Secrets.ControllerPublishVolumeSecret,
+					VolumeId:         vol.GetVolume().GetVolumeId(),
+					NodeId:           sc.Config.IDGen.GenerateUniqueValidNodeID(),
+					VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+					Readonly:         false,
+					Secrets:          sc.Secrets.ControllerPublishVolumeSecret,
 				},
 			)
 			Expect(err).To(HaveOccurred())
@@ -1395,14 +1285,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				&csi.CreateVolumeRequest{
 					Name: name,
 					VolumeCapabilities: []*csi.VolumeCapability{
-						{
-							AccessType: &csi.VolumeCapability_Mount{
-								Mount: &csi.VolumeCapability_MountVolume{},
-							},
-							AccessMode: &csi.VolumeCapability_AccessMode{
-								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-							},
-						},
+						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					},
 					Secrets:    sc.Secrets.CreateVolumeSecret,
 					Parameters: sc.Config.TestVolumeParameters,
@@ -1426,18 +1309,11 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 			By("calling controllerpublish on that volume")
 
 			pubReq := &csi.ControllerPublishVolumeRequest{
-				VolumeId: vol.GetVolume().GetVolumeId(),
-				NodeId:   nid.GetNodeId(),
-				VolumeCapability: &csi.VolumeCapability{
-					AccessType: &csi.VolumeCapability_Mount{
-						Mount: &csi.VolumeCapability_MountVolume{},
-					},
-					AccessMode: &csi.VolumeCapability_AccessMode{
-						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-					},
-				},
-				Readonly: false,
-				Secrets:  sc.Secrets.ControllerPublishVolumeSecret,
+				VolumeId:         vol.GetVolume().GetVolumeId(),
+				NodeId:           nid.GetNodeId(),
+				VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+				Readonly:         false,
+				Secrets:          sc.Secrets.ControllerPublishVolumeSecret,
 			}
 
 			conpubvol, err := c.ControllerPublishVolume(context.Background(), pubReq)
@@ -1535,14 +1411,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				&csi.CreateVolumeRequest{
 					Name: name,
 					VolumeCapabilities: []*csi.VolumeCapability{
-						{
-							AccessType: &csi.VolumeCapability_Mount{
-								Mount: &csi.VolumeCapability_MountVolume{},
-							},
-							AccessMode: &csi.VolumeCapability_AccessMode{
-								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-							},
-						},
+						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					},
 					Secrets:                   sc.Secrets.CreateVolumeSecret,
 					Parameters:                sc.Config.TestVolumeParameters,
@@ -1561,18 +1430,11 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 			conpubvol, err := c.ControllerPublishVolume(
 				context.Background(),
 				&csi.ControllerPublishVolumeRequest{
-					VolumeId: vol.GetVolume().GetVolumeId(),
-					NodeId:   ni.GetNodeId(),
-					VolumeCapability: &csi.VolumeCapability{
-						AccessType: &csi.VolumeCapability_Mount{
-							Mount: &csi.VolumeCapability_MountVolume{},
-						},
-						AccessMode: &csi.VolumeCapability_AccessMode{
-							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-						},
-					},
-					Readonly: false,
-					Secrets:  sc.Secrets.ControllerPublishVolumeSecret,
+					VolumeId:         vol.GetVolume().GetVolumeId(),
+					NodeId:           ni.GetNodeId(),
+					VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+					Readonly:         false,
+					Secrets:          sc.Secrets.ControllerPublishVolumeSecret,
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -2133,14 +1995,7 @@ var _ = DescribeSanity("ExpandVolume [Controller Server]", func(sc *TestContext)
 		req := &csi.CreateVolumeRequest{
 			Name: name,
 			VolumeCapabilities: []*csi.VolumeCapability{
-				{
-					AccessType: &csi.VolumeCapability_Mount{
-						Mount: &csi.VolumeCapability_MountVolume{},
-					},
-					AccessMode: &csi.VolumeCapability_AccessMode{
-						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-					},
-				},
+				TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 			},
 			Secrets: sc.Secrets.CreateVolumeSecret,
 			CapacityRange: &csi.CapacityRange{
@@ -2250,18 +2105,11 @@ func MakeDeleteVolumeReq(sc *TestContext, id string) *csi.DeleteVolumeRequest {
 // MakeControllerPublishVolumeReq creates and returns a ControllerPublishVolumeRequest.
 func MakeControllerPublishVolumeReq(sc *TestContext, volID, nodeID string) *csi.ControllerPublishVolumeRequest {
 	return &csi.ControllerPublishVolumeRequest{
-		VolumeId: volID,
-		NodeId:   nodeID,
-		VolumeCapability: &csi.VolumeCapability{
-			AccessType: &csi.VolumeCapability_Mount{
-				Mount: &csi.VolumeCapability_MountVolume{},
-			},
-			AccessMode: &csi.VolumeCapability_AccessMode{
-				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-			},
-		},
-		Readonly: false,
-		Secrets:  sc.Secrets.ControllerPublishVolumeSecret,
+		VolumeId:         volID,
+		NodeId:           nodeID,
+		VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+		Readonly:         false,
+		Secrets:          sc.Secrets.ControllerPublishVolumeSecret,
 	}
 }
 

--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -202,9 +202,10 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 			_, err := c.NodePublishVolume(
 				context.Background(),
 				&csi.NodePublishVolumeRequest{
-					VolumeId:   sc.Config.IDGen.GenerateUniqueValidVolumeID(),
-					TargetPath: sc.TargetPath + "/target",
-					Secrets:    sc.Secrets.NodePublishVolumeSecret,
+					VolumeId:         sc.Config.IDGen.GenerateUniqueValidVolumeID(),
+					VolumeCapability: nil,
+					TargetPath:       sc.TargetPath + "/target",
+					Secrets:          sc.Secrets.NodePublishVolumeSecret,
 				},
 			)
 			Expect(err).To(HaveOccurred())
@@ -261,14 +262,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 				context.Background(),
 				&csi.NodeStageVolumeRequest{
 					StagingTargetPath: sc.StagingPath,
-					VolumeCapability: &csi.VolumeCapability{
-						AccessType: &csi.VolumeCapability_Mount{
-							Mount: &csi.VolumeCapability_MountVolume{},
-						},
-						AccessMode: &csi.VolumeCapability_AccessMode{
-							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-						},
-					},
+					VolumeCapability:  TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					PublishContext: map[string]string{
 						"device": device,
 					},
@@ -286,15 +280,8 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 			_, err := c.NodeStageVolume(
 				context.Background(),
 				&csi.NodeStageVolumeRequest{
-					VolumeId: sc.Config.IDGen.GenerateUniqueValidVolumeID(),
-					VolumeCapability: &csi.VolumeCapability{
-						AccessType: &csi.VolumeCapability_Mount{
-							Mount: &csi.VolumeCapability_MountVolume{},
-						},
-						AccessMode: &csi.VolumeCapability_AccessMode{
-							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-						},
-					},
+					VolumeId:         sc.Config.IDGen.GenerateUniqueValidVolumeID(),
+					VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					PublishContext: map[string]string{
 						"device": device,
 					},
@@ -464,14 +451,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 				&csi.CreateVolumeRequest{
 					Name: name,
 					VolumeCapabilities: []*csi.VolumeCapability{
-						{
-							AccessType: &csi.VolumeCapability_Mount{
-								Mount: &csi.VolumeCapability_MountVolume{},
-							},
-							AccessMode: &csi.VolumeCapability_AccessMode{
-								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-							},
-						},
+						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					},
 					Secrets:    sc.Secrets.CreateVolumeSecret,
 					Parameters: sc.Config.TestVolumeParameters,
@@ -498,19 +478,12 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 				conpubvol, err = s.ControllerPublishVolume(
 					context.Background(),
 					&csi.ControllerPublishVolumeRequest{
-						VolumeId: vol.GetVolume().GetVolumeId(),
-						NodeId:   nid.GetNodeId(),
-						VolumeCapability: &csi.VolumeCapability{
-							AccessType: &csi.VolumeCapability_Mount{
-								Mount: &csi.VolumeCapability_MountVolume{},
-							},
-							AccessMode: &csi.VolumeCapability_AccessMode{
-								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-							},
-						},
-						VolumeContext: vol.GetVolume().GetVolumeContext(),
-						Readonly:      false,
-						Secrets:       sc.Secrets.ControllerPublishVolumeSecret,
+						VolumeId:         vol.GetVolume().GetVolumeId(),
+						NodeId:           nid.GetNodeId(),
+						VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+						VolumeContext:    vol.GetVolume().GetVolumeContext(),
+						Readonly:         false,
+						Secrets:          sc.Secrets.ControllerPublishVolumeSecret,
 					},
 				)
 				Expect(err).NotTo(HaveOccurred())
@@ -523,15 +496,8 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 				nodestagevol, err := c.NodeStageVolume(
 					context.Background(),
 					&csi.NodeStageVolumeRequest{
-						VolumeId: vol.GetVolume().GetVolumeId(),
-						VolumeCapability: &csi.VolumeCapability{
-							AccessType: &csi.VolumeCapability_Mount{
-								Mount: &csi.VolumeCapability_MountVolume{},
-							},
-							AccessMode: &csi.VolumeCapability_AccessMode{
-								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-							},
-						},
+						VolumeId:          vol.GetVolume().GetVolumeId(),
+						VolumeCapability:  TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 						StagingTargetPath: sc.StagingPath,
 						VolumeContext:     vol.GetVolume().GetVolumeContext(),
 						PublishContext:    conpubvol.GetPublishContext(),
@@ -553,17 +519,10 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 					VolumeId:          vol.GetVolume().GetVolumeId(),
 					TargetPath:        sc.TargetPath + "/target",
 					StagingTargetPath: stagingPath,
-					VolumeCapability: &csi.VolumeCapability{
-						AccessType: &csi.VolumeCapability_Mount{
-							Mount: &csi.VolumeCapability_MountVolume{},
-						},
-						AccessMode: &csi.VolumeCapability_AccessMode{
-							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-						},
-					},
-					VolumeContext:  vol.GetVolume().GetVolumeContext(),
-					PublishContext: conpubvol.GetPublishContext(),
-					Secrets:        sc.Secrets.NodePublishVolumeSecret,
+					VolumeCapability:  TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+					VolumeContext:     vol.GetVolume().GetVolumeContext(),
+					PublishContext:    conpubvol.GetPublishContext(),
+					Secrets:           sc.Secrets.NodePublishVolumeSecret,
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -670,14 +629,10 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 			&csi.CreateVolumeRequest{
 				Name: name,
 				VolumeCapabilities: []*csi.VolumeCapability{
-					{
-						AccessType: &csi.VolumeCapability_Mount{
-							Mount: &csi.VolumeCapability_MountVolume{},
-						},
-						AccessMode: &csi.VolumeCapability_AccessMode{
-							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-						},
-					},
+					TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+				},
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: TestVolumeSize(sc),
 				},
 				Secrets:                   sc.Secrets.CreateVolumeSecret,
 				Parameters:                sc.Config.TestVolumeParameters,
@@ -697,19 +652,12 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 			conpubvol, err = s.ControllerPublishVolume(
 				context.Background(),
 				&csi.ControllerPublishVolumeRequest{
-					VolumeId: vol.GetVolume().GetVolumeId(),
-					NodeId:   ni.GetNodeId(),
-					VolumeCapability: &csi.VolumeCapability{
-						AccessType: &csi.VolumeCapability_Mount{
-							Mount: &csi.VolumeCapability_MountVolume{},
-						},
-						AccessMode: &csi.VolumeCapability_AccessMode{
-							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-						},
-					},
-					VolumeContext: vol.GetVolume().GetVolumeContext(),
-					Readonly:      false,
-					Secrets:       sc.Secrets.ControllerPublishVolumeSecret,
+					VolumeId:         vol.GetVolume().GetVolumeId(),
+					NodeId:           ni.GetNodeId(),
+					VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+					VolumeContext:    vol.GetVolume().GetVolumeContext(),
+					Readonly:         false,
+					Secrets:          sc.Secrets.ControllerPublishVolumeSecret,
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -722,15 +670,8 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 			nodestagevol, err := c.NodeStageVolume(
 				context.Background(),
 				&csi.NodeStageVolumeRequest{
-					VolumeId: vol.GetVolume().GetVolumeId(),
-					VolumeCapability: &csi.VolumeCapability{
-						AccessType: &csi.VolumeCapability_Mount{
-							Mount: &csi.VolumeCapability_MountVolume{},
-						},
-						AccessMode: &csi.VolumeCapability_AccessMode{
-							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-						},
-					},
+					VolumeId:          vol.GetVolume().GetVolumeId(),
+					VolumeCapability:  TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					StagingTargetPath: sc.StagingPath,
 					VolumeContext:     vol.GetVolume().GetVolumeContext(),
 					PublishContext:    conpubvol.GetPublishContext(),
@@ -752,17 +693,10 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 				VolumeId:          vol.GetVolume().GetVolumeId(),
 				TargetPath:        sc.TargetPath + "/target",
 				StagingTargetPath: stagingPath,
-				VolumeCapability: &csi.VolumeCapability{
-					AccessType: &csi.VolumeCapability_Mount{
-						Mount: &csi.VolumeCapability_MountVolume{},
-					},
-					AccessMode: &csi.VolumeCapability_AccessMode{
-						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-					},
-				},
-				VolumeContext:  vol.GetVolume().GetVolumeContext(),
-				PublishContext: conpubvol.GetPublishContext(),
-				Secrets:        sc.Secrets.NodePublishVolumeSecret,
+				VolumeCapability:  TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+				VolumeContext:     vol.GetVolume().GetVolumeContext(),
+				PublishContext:    conpubvol.GetPublishContext(),
+				Secrets:           sc.Secrets.NodePublishVolumeSecret,
 			},
 		)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -95,6 +95,7 @@ type TestConfig struct {
 	TestVolumeParametersFile  string
 	TestVolumeParameters      map[string]string
 	TestNodeVolumeAttachLimit bool
+	TestVolumeAccessType      string
 
 	// JUnitFile is used by Test to store test results in JUnit
 	// format. When using GinkgoTest, the caller is responsible
@@ -182,6 +183,7 @@ func NewTestConfig() TestConfig {
 		CreatePathCmdTimeout: 10 * time.Second,
 		RemovePathCmdTimeout: 10 * time.Second,
 		TestVolumeSize:       10 * 1024 * 1024 * 1024, // 10 GiB
+		TestVolumeAccessType: "mount",
 		IDGen:                &DefaultIDGenerator{},
 
 		DialOptions:           []grpc.DialOption{grpc.WithInsecure()},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is 
/kind feature


**What this PR does / why we need it**:
It adds raw volumes tests.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #174

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
csi-sanity --csi.testvolumeaccesstype=block now runs CSI tests with raw block volumes.
```
