### PR TITLE
sanity: support embedding tests multiple time in Ginkgo

### DIFF
--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -231,6 +231,10 @@ func Test(t GinkgoTestingT, config TestConfig) {
 // GinkgoTest for use when the tests run. Therefore its content can
 // still be modified in a BeforeEach. The sanity package itself treats
 // it as read-only.
+//
+// Only tests defined with DescribeSanity after the last invocation with
+// GinkgoTest (if there has be one) will be added, i.e. each test only
+// gets added at most once.
 func GinkgoTest(config *TestConfig) *TestContext {
 	sc := newTestContext(config)
 	registerTestsInGinkgo(sc)

--- a/pkg/sanity/tests.go
+++ b/pkg/sanity/tests.go
@@ -53,4 +53,8 @@ func registerTestsInGinkgo(sc *TestContext) {
 			})
 		})
 	}
+	// Don't register tests more than once! More tests might
+	// be added later in a different context, followed by
+	// another registerTestsInGinkgo call.
+	tests = nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When using a sequence of DescribeSanity, RegisterTestsInGinkgo,
DescribeSanity, RegisterTestsInGinkgo (i.e. embedding sanity tests in
a Ginkgo suite more than once) the first test got registered multiple
times, first by the initial RegisterTestsInGinkgo and again in the
second RegisterTestsInGinkgo.

Not only is this wrong, the locally bound variables also weren't
initialized properly by the BeforeEach functions, which could lead to
nil pointer accesses.

**Special notes for your reviewer**:

Found in PMEM-CSI when I reorganized our E2E test suite.

**Does this PR introduce a user-facing change?**:
```release-note
repeatedly calling RegisterTestsInGinkgo now correctly adds tests only once
```
