### PR TITLE
Log full error code

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -219,15 +219,22 @@ func logGRPC(method string, request, reply interface{}, err error) {
 		Method   string
 		Request  interface{}
 		Response interface{}
-		Error    string
+		// Error as string, for backward compatibility.
+		// "" on no error.
+		Error string
+		// Full error dump, to be able to parse out full gRPC error code and message separately in a test.
+		FullError error
 	}{
-		Method:   method,
-		Request:  request,
-		Response: reply,
+		Method:    method,
+		Request:   request,
+		Response:  reply,
+		FullError: err,
 	}
+
 	if err != nil {
 		logMessage.Error = err.Error()
 	}
+
 	msg, _ := json.Marshal(logMessage)
 	fmt.Printf("gRPCCall: %s\n", msg)
 }


### PR DESCRIPTION
Dump whole error into gRPCCall logs, so we can check error code in e2e tests.

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
"gRPCCall" logs on standard output now include "fullError" with complete error structure. Typically, it contains "code" and "message" with gRPC error.
```
