### PR TITLE
sanity: support embedding tests multiple time in Ginkgo, II

### DIFF
--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -200,10 +200,10 @@ func NewTestConfig() TestConfig {
 	}
 }
 
-// newContext sets up sanity testing with a config supplied by the
+// NewContext sets up sanity testing with a config supplied by the
 // user of the sanity package. Ownership of that config is shared
 // between the sanity package and the caller.
-func newTestContext(config *TestConfig) *TestContext {
+func NewTestContext(config *TestConfig) *TestContext {
 	return &TestContext{
 		Config: config,
 	}
@@ -231,12 +231,8 @@ func Test(t GinkgoTestingT, config TestConfig) {
 // GinkgoTest for use when the tests run. Therefore its content can
 // still be modified in a BeforeEach. The sanity package itself treats
 // it as read-only.
-//
-// Only tests defined with DescribeSanity after the last invocation with
-// GinkgoTest (if there has be one) will be added, i.e. each test only
-// gets added at most once.
 func GinkgoTest(config *TestConfig) *TestContext {
-	sc := newTestContext(config)
+	sc := NewTestContext(config)
 	registerTestsInGinkgo(sc)
 	return sc
 }

--- a/pkg/sanity/tests.go
+++ b/pkg/sanity/tests.go
@@ -53,8 +53,4 @@ func registerTestsInGinkgo(sc *TestContext) {
 			})
 		})
 	}
-	// Don't register tests more than once! More tests might
-	// be added later in a different context, followed by
-	// another registerTestsInGinkgo call.
-	tests = nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This reverts commit ddf8b3f0982c83ad64cc5ff403874b4eab1dd985. It was
meant to enable the call sequence DescribeSanity,
RegisterTestsInGinkgo, DescribeSanity, RegisterTestsInGinkgo, but that
call sequence is invalid: DescribeSanity must be called during the
init phase, then RegisterTestsInGinkgo may be called multiple times
with different configs.

That usage got broken by the commit above because the second
RegisterTestsInGinkgo then didn't add any of the tests defined by the
sanity package.

**Special notes for your reviewer**:

The regression was noticed when using the "fix" in PMEM-CSI. Now *both* usecases (registering existing tests and custom tests multiple times) have been verified...

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
