### PR TITLE
Add descriptions to To() expectations in NodeUnpublishVolume

### DIFF
--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -428,11 +428,11 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 					VolumeId:   sc.Config.IDGen.GenerateUniqueValidVolumeID(),
 					TargetPath: sc.StagingPath,
 				})
-			Expect(err).To(HaveOccurred())
+			Expect(err).To(HaveOccurred(), "failed to unpublish volume from node")
 
 			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.NotFound))
+			Expect(ok).To(BeTrue(), "error from NodeUnpublishVolume is not a gRPC error")
+			Expect(serverError.Code()).To(Equal(codes.NotFound), "unexpected error code")
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

It adds descriptions to To() expectations in `NodeUnpublishVolume`. Without these, `To()` expectations are unnecessarily difficult to understand.

Follow-up of @pohly's comment [here](https://github.com/kubernetes-csi/csi-test/pull/242#discussion_r366888878).

**Which issue(s) this PR fixes**:
Relates to #242.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @pohly 