### PR TITLE
sanity: allow `Volume` `capacity_bytes` to be zero

### DIFF
--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -482,7 +482,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 			Expect(vol.GetVolume()).NotTo(BeNil())
 			Expect(vol.GetVolume().GetVolumeId()).NotTo(BeEmpty())
 			cl.RegisterVolume(name, VolumeInfo{VolumeID: vol.GetVolume().GetVolumeId()})
-			Expect(vol.GetVolume().GetCapacityBytes()).To(BeNumerically(">=", TestVolumeSize(sc)))
+			Expect(vol.GetVolume().GetCapacityBytes()).To(Or(BeNumerically(">=", TestVolumeSize(sc)), BeZero()))
 
 			By("cleaning up deleting the volume")
 
@@ -521,7 +521,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 			Expect(vol1.GetVolume()).NotTo(BeNil())
 			Expect(vol1.GetVolume().GetVolumeId()).NotTo(BeEmpty())
 			cl.RegisterVolume(name, VolumeInfo{VolumeID: vol1.GetVolume().GetVolumeId()})
-			Expect(vol1.GetVolume().GetCapacityBytes()).To(BeNumerically(">=", size))
+			Expect(vol1.GetVolume().GetCapacityBytes()).To(Or(BeNumerically(">=", size), BeZero()))
 
 			vol2, err := c.CreateVolume(
 				context.Background(),
@@ -541,7 +541,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 			Expect(vol2).NotTo(BeNil())
 			Expect(vol2.GetVolume()).NotTo(BeNil())
 			Expect(vol2.GetVolume().GetVolumeId()).NotTo(BeEmpty())
-			Expect(vol2.GetVolume().GetCapacityBytes()).To(BeNumerically(">=", size))
+			Expect(vol2.GetVolume().GetCapacityBytes()).To(Or(BeNumerically(">=", size), BeZero()))
 			Expect(vol1.GetVolume().GetVolumeId()).To(Equal(vol2.GetVolume().GetVolumeId()))
 
 			By("cleaning up deleting the volume")
@@ -646,7 +646,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 			Expect(vol.GetVolume()).NotTo(BeNil())
 			Expect(vol.GetVolume().GetVolumeId()).NotTo(BeEmpty())
 			cl.RegisterVolume(name, VolumeInfo{VolumeID: vol.GetVolume().GetVolumeId()})
-			Expect(vol.GetVolume().GetCapacityBytes()).To(BeNumerically(">=", size))
+			Expect(vol.GetVolume().GetCapacityBytes()).To(Or(BeNumerically(">=", size), BeZero()))
 
 			By("cleaning up deleting the volume")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
From the CSI spec:

> The capacity of the volume in bytes. This field is OPTIONAL. If not
> set (value of 0), it indicates that the capacity of the volume is
> unknown (e.g., NFS share).
> The value of this field MUST NOT be negative.

As such, the tests that validate the result of a `CreateVolume`
operation shall accept zero as the `capacity_bytes` of the returned
`Volume` object, when validating this value against the requested
capacity.

See: https://github.com/container-storage-interface/spec/blob/e129a75169c13bade7c7336afe21f259740ba679/spec.md#createvolume

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #94 but not fixing it completely (cfr. #263).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The tests that validate the result of a `CreateVolume` operation now accept zero as the `capacity_bytes` of the returned `Volume` object, when validating this value against the requested
capacity.
```