### PR TITLE
sanity: volumes of zero capacity can be recreated

### DIFF
--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -582,6 +582,11 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 			Expect(vol1.GetVolume()).NotTo(BeNil())
 			Expect(vol1.GetVolume().GetVolumeId()).NotTo(BeEmpty())
 			cl.RegisterVolume(name, VolumeInfo{VolumeID: vol1.GetVolume().GetVolumeId()})
+
+			if vol1.GetVolume().GetCapacityBytes() == 0 {
+				Skip("Reported volume capacity is 0, no conflict expected")
+			}
+
 			size2 := 2 * TestVolumeSize(sc)
 
 			_, err = c.CreateVolume(


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In general, when creating a volume of some requested capacity using
`CreateVolume`, then re-running the RPC with the same name but different
capacity request, this ought to fail with `ALREADY_EXISTS` (according to
the spec). However, when the reported capacity of a volume equals zero,
the volume capacity is unknown (again according to the spec). As such,
when issueing another `CreateVolume` call using the same name but a
different requested capacity, this should not necessarily fail, since a
volume whose size is (theoretically) unlimited is compatible with *any*
requested capacity.

This is in line with the spec:

> Indicates that a volume corresponding to the specified volume name
> already exists but is incompatible with the specified capacity_range,
> volume_capabilities or parameters.

Given this, the relevant test is updated to *skip* when the capacity as
returned by the first `CreateVolume` call equals zero.

**Which issue(s) this PR fixes**:
Fixes #94

**Special notes for your reviewer**:
This is, of course, according to a particular reading of the CSI spec, which may be debatable. However, see https://github.com/kubernetes-csi/csi-test/issues/94#issuecomment-620819417 as to why the current test is problematic for some SPs.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
