### PR TITLE
sanity: Add more input validation tests to node service

### DIFF
--- a/hack/_apitest2/api_test.go
+++ b/hack/_apitest2/api_test.go
@@ -15,10 +15,10 @@ func TestMyDriverWithCustomTargetPaths(t *testing.T) {
 	var createTargetDirCalls, createStagingDirCalls,
 		removeTargetDirCalls, removeStagingDirCalls int
 
-	wantCreateTargetCalls := 3
-	wantCreateStagingCalls := 3
-	wantRemoveTargetCalls := 3
-	wantRemoveStagingCalls := 3
+	wantCreateTargetCalls := 4
+	wantCreateStagingCalls := 4
+	wantRemoveTargetCalls := 4
+	wantRemoveStagingCalls := 4
 
 	// tmpPath could be a CO specific directory under which all the target dirs
 	// are created. For k8s, it could be /var/lib/kubelet/pods under which the

--- a/hack/_apitest2/api_test.go
+++ b/hack/_apitest2/api_test.go
@@ -15,10 +15,10 @@ func TestMyDriverWithCustomTargetPaths(t *testing.T) {
 	var createTargetDirCalls, createStagingDirCalls,
 		removeTargetDirCalls, removeStagingDirCalls int
 
-	wantCreateTargetCalls := 4
-	wantCreateStagingCalls := 4
-	wantRemoveTargetCalls := 4
-	wantRemoveStagingCalls := 4
+	wantCreateTargetCalls := 5
+	wantCreateStagingCalls := 5
+	wantRemoveTargetCalls := 5
+	wantRemoveStagingCalls := 5
 
 	// tmpPath could be a CO specific directory under which all the target dirs
 	// are created. For k8s, it could be /var/lib/kubelet/pods under which the

--- a/mock/service/node.go
+++ b/mock/service/node.go
@@ -140,6 +140,10 @@ func (s *service) NodePublishVolume(
 		return nil, status.Error(codes.InvalidArgument, "Volume ID cannot be empty")
 	}
 
+	if len(req.GetStagingTargetPath()) == 0 {
+		return nil, status.Error(codes.FailedPrecondition, "StagingTarget Path cannot be empty")
+	}
+
 	if len(req.GetTargetPath()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Target Path cannot be empty")
 	}

--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -346,13 +346,34 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 	})
 
 	Describe("NodePublishVolume", func() {
+		var req *csi.NodePublishVolumeRequest
+
+		BeforeEach(func() {
+			stagingTargetPath := ""
+			if nodeStageSupported {
+				stagingTargetPath = sc.StagingPath
+			}
+
+			req = &csi.NodePublishVolumeRequest{
+				VolumeId:          sc.Config.IDGen.GenerateUniqueValidVolumeID(),
+				StagingTargetPath: stagingTargetPath,
+				TargetPath:        sc.TargetPath + "/target",
+				VolumeCapability:  TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+				Readonly:          false,
+				Secrets:           sc.Secrets.NodePublishVolumeSecret,
+			}
+		})
+
+		JustAfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				fmt.Fprintf(GinkgoWriter, "Request was %v\n", req)
+			}
+		})
+
 		It("should fail when no volume id is provided", func() {
-			_, err := c.NodePublishVolume(
-				context.Background(),
-				&csi.NodePublishVolumeRequest{
-					Secrets: sc.Secrets.NodePublishVolumeSecret,
-				},
-			)
+			req.VolumeId = ""
+
+			_, err := c.NodePublishVolume(context.Background(), req)
 			Expect(err).To(HaveOccurred())
 
 			serverError, ok := status.FromError(err)
@@ -361,13 +382,9 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 		})
 
 		It("should fail when no target path is provided", func() {
-			_, err := c.NodePublishVolume(
-				context.Background(),
-				&csi.NodePublishVolumeRequest{
-					VolumeId: sc.Config.IDGen.GenerateUniqueValidVolumeID(),
-					Secrets:  sc.Secrets.NodePublishVolumeSecret,
-				},
-			)
+			req.TargetPath = ""
+
+			_, err := c.NodePublishVolume(context.Background(), req)
 			Expect(err).To(HaveOccurred())
 
 			serverError, ok := status.FromError(err)
@@ -376,15 +393,9 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 		})
 
 		It("should fail when no volume capability is provided", func() {
-			_, err := c.NodePublishVolume(
-				context.Background(),
-				&csi.NodePublishVolumeRequest{
-					VolumeId:         sc.Config.IDGen.GenerateUniqueValidVolumeID(),
-					VolumeCapability: nil,
-					TargetPath:       sc.TargetPath + "/target",
-					Secrets:          sc.Secrets.NodePublishVolumeSecret,
-				},
-			)
+			req.VolumeCapability = nil
+
+			_, err := c.NodePublishVolume(context.Background(), req)
 			Expect(err).To(HaveOccurred())
 
 			serverError, ok := status.FromError(err)
@@ -393,20 +404,9 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 		})
 
 		It("should fail when the volume is missing", func() {
-			stagingPath := ""
-			if nodeStageSupported {
-				stagingPath = sc.StagingPath
-			}
+			req.VolumeId = sc.Config.IDGen.GenerateUniqueValidVolumeID()
 
-			_, err := c.NodePublishVolume(
-				context.Background(),
-				&csi.NodePublishVolumeRequest{
-					VolumeId:          sc.Config.IDGen.GenerateUniqueValidVolumeID(),
-					VolumeCapability:  TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
-					StagingTargetPath: stagingPath,
-					TargetPath:        sc.TargetPath + "/target",
-					Secrets:           sc.Secrets.NodePublishVolumeSecret,
-				})
+			_, err := c.NodePublishVolume(context.Background(), req)
 			Expect(err).To(HaveOccurred())
 
 			serverError, ok := status.FromError(err)

--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -392,6 +392,21 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 			Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
 		})
 
+		It("should fail when no staging target path is provided", func() {
+			if !nodeStageSupported {
+				Skip("STAGE_UNSTAGE_VOLUME not supported")
+			}
+
+			req.StagingTargetPath = ""
+
+			_, err := c.NodePublishVolume(context.Background(), req)
+			Expect(err).To(HaveOccurred())
+
+			serverError, ok := status.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(serverError.Code()).To(Equal(codes.FailedPrecondition))
+		})
+
 		It("should fail when no volume capability is provided", func() {
 			req.VolumeCapability = nil
 

--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -487,6 +487,25 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 			Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
 		})
 
+		It("should fail when the volume is missing", func() {
+			_, err := c.NodeStageVolume(
+				context.Background(),
+				&csi.NodeStageVolumeRequest{
+					VolumeId:         sc.Config.IDGen.GenerateUniqueValidVolumeID(),
+					VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+					PublishContext: map[string]string{
+						"device": device,
+					},
+					StagingTargetPath: sc.StagingPath,
+				})
+			Expect(err).To(HaveOccurred())
+
+			serverError, ok := status.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(serverError.Code()).To(Equal(codes.NotFound))
+
+		})
+
 		It("should fail when no volume capability is provided", func() {
 
 			// Create Volume First
@@ -581,6 +600,20 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 			serverError, ok := status.FromError(err)
 			Expect(ok).To(BeTrue())
 			Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+		})
+
+		It("should fail when the volume is missing", func() {
+			_, err := c.NodeUnstageVolume(
+				context.Background(),
+				&csi.NodeUnstageVolumeRequest{
+					VolumeId:          sc.Config.IDGen.GenerateUniqueValidVolumeID(),
+					StagingTargetPath: sc.StagingPath,
+				})
+			Expect(err).To(HaveOccurred())
+
+			serverError, ok := status.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(serverError.Code()).To(Equal(codes.NotFound))
 		})
 	})
 

--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -391,6 +391,28 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 			Expect(ok).To(BeTrue())
 			Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
 		})
+
+		It("should fail when the volume is missing", func() {
+			stagingPath := ""
+			if nodeStageSupported {
+				stagingPath = sc.StagingPath
+			}
+
+			_, err := c.NodePublishVolume(
+				context.Background(),
+				&csi.NodePublishVolumeRequest{
+					VolumeId:          sc.Config.IDGen.GenerateUniqueValidVolumeID(),
+					VolumeCapability:  TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+					StagingTargetPath: stagingPath,
+					TargetPath:        sc.TargetPath + "/target",
+					Secrets:           sc.Secrets.NodePublishVolumeSecret,
+				})
+			Expect(err).To(HaveOccurred())
+
+			serverError, ok := status.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(serverError.Code()).To(Equal(codes.NotFound))
+		})
 	})
 
 	Describe("NodeUnpublishVolume", func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
- Test for `NOT_FOUND` on `NodeStageVolume` and `NodeUnstageVolume` for unknown volumes
- Test for `NOT_FOUND` on `NodePublishVolume` for unknown volumes
- Rework the `NodePublishVolume` tests to not depend on input validation ordering inside the driver
- Test for `FAILED_PRECONDITION` on `NodePublishVolume` if `STAGE_UNSTAGE_VOLUME` is supported

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- The `csi-sanity` test suite now validates a nodeplugin returns `NOT_FOUND` when `NodeStageVolume` or `NodeUnstageVolume` is called given a non-existing `volume_id`.
- The `csi-sanity` test suite now validates a nodeplugin returns `NOT_FOUND` when `NodePublishVolume` is called given a non-existing `volume_id`.
- The `csi-sanity` test suite now validates a nodeplugin with the `STAGE_UNSTAGE_VOLUME` capability returns `FAILED_PRECONDITION` when `NodePublishVolume` is called given an empty `staging_target_path`.
```
