### PR TITLE
CHANGELOG-3.1.md: prepare for v3.1.1

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,3 +1,18 @@
+# Changelog since v3.1.0
+
+## Bug Fixes
+
+- The tests that validate the result of a `CreateVolume` operation now accept zero as the `capacity_bytes` of the returned `Volume` object, when validating this value against the requested
+  capacity. ([#262](https://github.com/kubernetes-csi/csi-test/pull/262), [@NicolasT](https://github.com/NicolasT))
+
+## Other Notable Changes
+
+- Publishing of images on k8s.gcr.io ([#270](https://github.com/kubernetes-csi/csi-test/pull/270), [@pohly](https://github.com/pohly))
+- Remove missing volume test case for NodeUnpublishVolume ([#258](https://github.com/kubernetes-csi/csi-test/pull/258), [@timoreimann](https://github.com/timoreimann))
+- Update release-tools to 9084fec to support native building ([#267](https://github.com/kubernetes-csi/csi-test/pull/267), [@timoreimann](https://github.com/timoreimann))
+
+# Changelog since v3.0.0
+
 ## New Features
 
 - "gRPCCall" logs on standard output now include "fullError" with complete error structure. Typically, it contains "code" and "message" with gRPC error. ([#254](https://github.com/kubernetes-csi/csi-test/pull/254), [@jsafrane](https://github.com/jsafrane))


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Let's do a v3.1.1 to include some fixes and have a new mock driver image in staging that we can promote.

**Which issue(s) this PR fixes**:
Related-to: https://github.com/kubernetes-csi/csi-release-tools/issues/86#issuecomment-634509901

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
