### PR TITLE
Add mock CSI driver deploy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ It follows the same release cycle as other containers, so the latest release is 
 You will need to setup the environment variable `CSI_ENDPOINT` for the mock driver to know where to create the unix
 domain socket.
 
+There is an [example](https://github.com/kubernetes-csi/csi-test/tree/master/mock/example) deployment
+for experiment with the mock csi driver.
+
 For more complicated test-cases see [how to use JavaScript hooks from the driver](hooks-howto.md).
 
 ## For CSI Driver Tests

--- a/mock/README.md
+++ b/mock/README.md
@@ -11,6 +11,11 @@ Usage of mock:
         CSI driver name. (default "io.kubernetes.storage.mock")
 ```
 
+Limitation about this mock CSI Driver are:
+- It only supports single node.
+- It requires all the components to run on the same node, i.e. the pod that uses pv created by this CSI driver should be on the same node with the driver.
+- It does not persist data across restarts. All the states are in memory.
+
 It prints all received CSI messages to stdout encoded as json, so a test can check that
 CO sent the right CSI message.
 
@@ -20,3 +25,36 @@ Example of such output:
 gRPCCall: {"Method":"/csi.v0.Controller/ControllerGetCapabilities","Request":{},"Response":{"capabilities":[{"Type":{"Rpc":{"type":1}}},{"Type":{"Rpc":{"type":3}}},{"Type":{"Rpc":{"type":4}}},{"Type":{"Rpc":{"type":6}}},{"Type":{"Rpc":{"type":5}}},{"Type":{"Rpc":{"type":2}}}]},"Error":""}
 gRPCCall: {"Method":"/csi.v0.Controller/ControllerPublishVolume","Request":{"volume_id":"12","node_id":"some-fake-node-id","volume_capability":{"AccessType":{"Mount":{}},"access_mode":{"mode":1}}},"Response":null,"Error":"rpc error: code = NotFound desc = Not matching Node ID some-fake-node-id to Mock Node ID io.kubernetes.storage.mock"}
 ```
+
+## Mock CSI Driver Example
+
+This example requires kubernetes 1.18+
+
+The example folder contains an example manifest of deploying CSIDriver including `csi-driver-node-registrar`, `csi-provisioner`,
+`csi-resizer` and `csi-snapshotter` onto a cluster. For testing purpose, `csi-attacher` is not included. Thus, 
+`"--disable-attach=true"` is set on the csi mock driver.
+
+### Usage
+
+To install the CSI mock driver in your cluster.
+```
+$ kubectl apply -f example/deploy/csi-mock-driver-rbac.yaml
+$ kubectl apply -f example/deploy/csi-mock-driver-deployment.yaml
+```
+
+This will deploy a `CSIDriver` called `io.kubernetes.storage.mock`. There will be a deployment `csi-mockplugin` being 
+installed in the default namespace. Correspondingly, you can find a pod with prefix `csi-mockplugin`. In the meantime,
+ a `StorageClass` called `test-csi-mock` will be generated along with a `VolumeSnapshotClass` called `csi-mock-snapclass`.
+
+K8s distribution 1.17+ is supposed to install [snapshot-controller](https://github.com/kubernetes-csi/external-snapshotter#design)
+by default. However, if it does not, you need to install it manually follow the [external-snapshotter doc](https://github.com/kubernetes-csi/external-snapshotter#usage) to test the snapshot feature.
+
+
+### Experiment
+
+Recommended steps to follow:
+
+1. Deploy `example/pvc-test.yaml` to test the provisioner. Edit the pvc spec to test csi volume resizer.
+2. Deploy `example/pod-test.yaml` to test volume mounting.
+3. Deploy `example/snapshot-test.yaml` to test snapshot of the pvc deployed in step 1.
+4. Deploy `example/snapshot-restore-test.yaml` to test restore volume from a snapshot generated from step 3s.

--- a/mock/example/README.md
+++ b/mock/example/README.md
@@ -1,0 +1,1 @@
+Please refer to [mock csi driver example](https://github.com/kubernetes-csi/csi-test/tree/master/mock#mock-csi-driver-example) section for how to play with it.

--- a/mock/example/deploy/csi-mock-driver-deployment.yaml
+++ b/mock/example/deploy/csi-mock-driver-deployment.yaml
@@ -1,0 +1,126 @@
+# This YAML file contains the deployment of the CSIDriver
+# including node-driver-registrar, external-provisioner, external-snapshotter
+# external-resizer and mock-driver
+#
+# This YAML file also includes deployment of the CSIDriver, StorageClass
+# VolumeSnapshotClass for the mock driver.
+
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: csi-mockplugin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-mockplugin
+  template:
+    metadata:
+      labels:
+        app: csi-mockplugin
+    spec:
+      serviceAccount: csi-mock
+      containers:
+        - name: csi-provisioner
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v1.6.0
+          args:
+            - "--csi-address=/csi/csi.sock"
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          # Normally privileged: true is only required for the driver container to perform 
+          # the mount operation. However, privileged container is necessary for systems with 
+          # SELinux, where non-privileged sidecar containers cannot access unix domain socket
+          # created by privileged CSI driver container. The other containers in this file being 
+          # granted privileged permission are for the same reason.
+          securityContext:
+            privileged: true
+        - name: node-driver-registrar
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/io.kubernetes.storage.mock/csi.sock
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - mountPath: /csi
+            name: socket-dir
+          - mountPath: /registration
+            name: registration-dir
+        - name: csi-resizer
+          image: k8s.gcr.io/sig-storage/csi-resizer:v0.5.0
+          args:
+            - "--v=5"
+            - "--csi-address=/csi/csi.sock"
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - mountPath: /csi
+            name: socket-dir
+        - name: csi-snapshotter
+          image:  k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.0
+          args:
+            - "--v=5"
+            - "--csi-address=/csi/csi.sock"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          securityContext:
+            privileged: true
+        - name: mock-driver
+          image: k8s.gcr.io/sig-storage/mock-driver:v3.1.0
+          args:
+            - "--disable-attach=true"
+          env:
+            - name: CSI_ENDPOINT
+              value: /csi/csi.sock
+          # The driver container has to be privileged in order to do mount operation
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/io.kubernetes.storage.mock
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+
+---
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: io.kubernetes.storage.mock
+spec:
+  attachRequired: false
+  podInfoOnMount: false
+
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: test-csi-mock 
+provisioner: io.kubernetes.storage.mock
+allowVolumeExpansion: true
+parameters:
+
+
+---
+apiVersion: snapshot.storage.k8s.io/v1beta1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-mock-snapclass
+driver: io.kubernetes.storage.mock
+deletionPolicy: Delete

--- a/mock/example/deploy/csi-mock-driver-rbac.yaml
+++ b/mock/example/deploy/csi-mock-driver-rbac.yaml
@@ -1,0 +1,123 @@
+# This YAML file contains all RBAC objects that are necessary to run external
+# CSI provisioner, resizer and snapshotter.
+#
+# In production, each CSI driver deployment has to be customized:
+# - to avoid conflicts, use non-default namespace and different names
+#   for non-namespaced entities like the ClusterRole
+# - decide whether the deployment replicates the external CSI
+#   provisioner and resizer, in which case leadership election must be enabled;
+#   this influences the RBAC setup, see below
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-mock
+  # replace with non-default namespace name
+  namespace: default
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mock-runner
+rules:
+  # The following rule should be uncommented for plugins that require secrets
+  # for provisioning.
+  # - apiGroups: [""]
+  #   resources: ["secrets"]
+  #   verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status", "volumesnapshotcontents/status"]
+    verbs: ["update"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-mock-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-mock
+    # replace with non-default namespace name
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: mock-runner
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Provisioner must be able to work with endpoints in current namespace
+# if (and only if) leadership election is enabled
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # replace with non-default namespace name
+  namespace: default
+  name: mock-cfg
+rules:
+# Only one of the following rules for endpoints or leases is required based on
+# what is set for `--leader-election-type`. Endpoints are deprecated in favor of Leases.
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-mock-role-cfg
+  # replace with non-default namespace name
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: csi-mock
+    # replace with non-default namespace name
+    namespace: default
+roleRef:
+  kind: Role
+  name: mock-cfg
+  apiGroup: rbac.authorization.k8s.io

--- a/mock/example/pod-test.yaml
+++ b/mock/example/pod-test.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web-server
+spec:
+  # TODO: As a future improvement, if we add topology support to the mock driver, 
+  # then we don't need podAffinity in this pod. The pv provisioned will have a 
+  # nodeaffinity on it, and the pod will always get scheduled to the correct node.
+  #
+  # Deploy this pod only on where csi-mock-driver exists.
+  # This is because csi-mock-driver keeps all states in memory and the process that
+  # provisioned the PV needs to be the same process that's mounting it.
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - csi-mockplugin
+        topologyKey: "kubernetes.io/hostname"
+  containers:
+   - name: web-server
+     image: nginx 
+     volumeMounts:
+       - mountPath: /var/lib/www/html
+         name: mypvc
+  volumes:
+   - name: mypvc
+     persistentVolumeClaim:
+       claimName: example-pvc
+       readOnly: false

--- a/mock/example/pvc-test.yaml
+++ b/mock/example/pvc-test.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: example-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: test-csi-mock 
+  resources:
+    requests:
+      storage: 1Mi

--- a/mock/example/snapshot-restore-test.yaml
+++ b/mock/example/snapshot-restore-test.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: snapshot-mock-driver-restore
+spec:
+  storageClassName: test-csi-mock
+  dataSource:
+    name: csi-mock-snapshot-test 
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Mi

--- a/mock/example/snapshot-test.yaml
+++ b/mock/example/snapshot-test.yaml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1beta1
+kind: VolumeSnapshot
+metadata:
+  name: csi-mock-snapshot-test
+spec:
+  volumeSnapshotClassName: csi-mock-snapclass
+  source:
+    persistentVolumeClaimName: example-pvc


### PR DESCRIPTION
This commit adds an example folder which contains a deploy instruction
of the full CSI mock driver including csi-provisioner, csi-resizer,
csi-snapshotter and csi-node-driver-registrar.

This helps to playaround with the CSI mock driver to understand the
functionality.

Tested on GCP.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
/kind example

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This is a demo deployment of mock csi driver with all the containers.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Deployment manifests and examples are added for mock CSI driver under `mock/example`
```
