### PR TITLE
Add CSI LIST_VOLUMES_PUBLISHED_NODES to the controller in mock

### DIFF
--- a/mock/service/controller.go
+++ b/mock/service/controller.go
@@ -501,6 +501,13 @@ func (s *service) ControllerGetCapabilities(
 		{
 			Type: &csi.ControllerServiceCapability_Rpc{
 				Rpc: &csi.ControllerServiceCapability_RPC{
+					Type: csi.ControllerServiceCapability_RPC_LIST_VOLUMES_PUBLISHED_NODES,
+				},
+			},
+		},
+		{
+			Type: &csi.ControllerServiceCapability_Rpc{
+				Rpc: &csi.ControllerServiceCapability_RPC{
 					Type: csi.ControllerServiceCapability_RPC_GET_CAPACITY,
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind feature

**What this PR does / why we need it**:

This adds the LIST_VOLUMES_PUBLISHED_NODES capability to the mock. This will enable mock to be usable in cases such as CSI attacher reconciler. Ref: [this logic](https://github.com/kubernetes-csi/external-attacher/blob/298cb965f909f76f2d2dfa2062cb5e142f14b9d5/cmd/csi-attacher/main.go#L169) in the external-attacher. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Used this modified csi-mock to verify this [fix](https://github.com/kubernetes-csi/external-attacher/pull/244) in external-attacher. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add CSI LIST_VOLUMES_PUBLISHED_NODES capability to csi-mock
```
