### PR TITLE
master: update release-tools

### DIFF
--- a/mock/service/service.go
+++ b/mock/service/service.go
@@ -175,7 +175,7 @@ func (s *service) newVolumeFromSnapshot(name string, capacity int64, snapshotID 
 	vol.ContentSource = &csi.VolumeContentSource{
 		Type: &csi.VolumeContentSource_Snapshot{
 			Snapshot: &csi.VolumeContentSource_SnapshotSource{
-				SnapshotId: string(snapshotID),
+				SnapshotId: fmt.Sprintf("%d", snapshotID),
 			},
 		},
 	}
@@ -188,7 +188,7 @@ func (s *service) newVolumeFromVolume(name string, capacity int64, volumeID int)
 	vol.ContentSource = &csi.VolumeContentSource{
 		Type: &csi.VolumeContentSource_Volume{
 			Volume: &csi.VolumeContentSource_VolumeSource{
-				VolumeId: string(volumeID),
+				VolumeId: fmt.Sprintf("%d", volumeID),
 			},
 		},
 	}

--- a/release-tools/SIDECAR_RELEASE_PROCESS.md
+++ b/release-tools/SIDECAR_RELEASE_PROCESS.md
@@ -86,6 +86,12 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
    [external-provisioner example](https://github.com/kubernetes-csi/external-provisioner/releases/new)
 1. If release was a new major/minor version, create a new `release-<minor>`
    branch at that commit.
+1. Check [image build status](https://k8s-testgrid.appspot.com/sig-storage-image-build).
+1. Promote images from k8s-staging-sig-storage to k8s.gcr.io/sig-storage. From
+   the [k8s image
+   repo](https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io/images/k8s-staging-sig-storage),
+   run `./generate.sh > images.yaml`, and send a PR with the updated images.
+   Once merged, the image promoter will copy the images from staging to prod.
 1. Update [kubernetes-csi/docs](https://github.com/kubernetes-csi/docs) sidecar
    and feature pages with the new released version.
 1. After all the sidecars have been released, update

--- a/release-tools/travis.yml
+++ b/release-tools/travis.yml
@@ -6,7 +6,7 @@ git:
   depth: false
 matrix:
   include:
-  - go: 1.13.3
+  - go: 1.15
 before_script:
 - mkdir -p bin
 - wget https://github.com/golang/dep/releases/download/v0.5.1/dep-linux-amd64 -O bin/dep


### PR DESCRIPTION
Commit summary:
0979c09 prow.sh: fix E2E suite for Kubernetes >= 1.18
3b4a2f1 prow.sh: fix installing Go for Kubernetes 1.19.0
82d108a switch to Go 1.15
843bddc Add steps on promoting release images

```release-note
build with Go 1.15
```