### PR TITLE
Cleanup snapshots before volumes

### DIFF
--- a/pkg/sanity/resources.go
+++ b/pkg/sanity/resources.go
@@ -248,8 +248,8 @@ func (cl *Resources) Cleanup() {
 	defer cl.mutex.Unlock()
 	ctx := context.Background()
 
-	cl.deleteVolumes(ctx, 2)
 	cl.deleteSnapshots(ctx, 2)
+	cl.deleteVolumes(ctx, 2)
 }
 
 func (cl *Resources) deleteVolumes(ctx context.Context, offset int) {


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:

#261 accidentally swapped the cleanup order to deleting volumes before snapshots. This represents a deviation to the previous behavior that not all CSI drivers may be able to handle. This change restores the original order.

**Does this PR introduce a user-facing change?**:
```release-note
Restore snapshots-before-volumes cleanup order
```

/assign @pohly 

@apurv15 thanks for [reporting](https://github.com/kubernetes-csi/csi-test/pull/261#commitcomment-41920022)
