### PR TITLE
sanity: add missing TestVolumeParameters to CreateVolume calls

### DIFF
--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -224,7 +224,8 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				VolumeCapabilities: []*csi.VolumeCapability{
 					TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 				},
-				Secrets: sc.Secrets.CreateVolumeSecret,
+				Secrets:    sc.Secrets.CreateVolumeSecret,
+				Parameters: sc.Config.TestVolumeParameters,
 			}
 
 			vol := r.MustCreateVolume(context.Background(), req)
@@ -297,7 +298,8 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 						VolumeCapabilities: []*csi.VolumeCapability{
 							TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 						},
-						Secrets: sc.Secrets.CreateVolumeSecret,
+						Secrets:    sc.Secrets.CreateVolumeSecret,
+						Parameters: sc.Config.TestVolumeParameters,
 					}
 
 					vol, err := r.CreateVolume(context.Background(), req)
@@ -340,7 +342,8 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				VolumeCapabilities: []*csi.VolumeCapability{
 					TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 				},
-				Secrets: sc.Secrets.CreateVolumeSecret,
+				Secrets:    sc.Secrets.CreateVolumeSecret,
+				Parameters: sc.Config.TestVolumeParameters,
 			}
 			vol := r.MustCreateVolume(context.Background(), req)
 			existing_vols[vol.Volume.VolumeId] = true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Add volume parameters to some `CreateVolume` calls that missed it, so to comply with the `csi.testvolumeparameters` flag.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #291

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
