### PR TITLE
Revert to multiarch distroless base

### DIFF
--- a/cmd/mock-driver/Dockerfile
+++ b/cmd/mock-driver/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static:latest-amd64
+FROM gcr.io/distroless/static:latest
 LABEL maintainers="Kubernetes Authors"
 LABEL description="CSI Mock Driver"
 ARG binary=./bin/mock-driver


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Support for s390x/ppc64le has been added to distroless static/base images and hence the Dockerfiles can go back to using multiarch images.

**Which issue(s) this PR fixes**:

Fixes #  kubernetes-csi/csi-release-tools#105

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Changing distroless image back to multiarch
```
