### PR TITLE
Create target directory if it doesn't exist

### DIFF
--- a/mock/service/node.go
+++ b/mock/service/node.go
@@ -203,15 +203,19 @@ func (s *service) NodePublishVolume(
 			ISEphemeral: true,
 		}
 	} else {
-		if req.GetStagingTargetPath() != "" {
-			exists, err := checkTargetExists(req.GetStagingTargetPath())
+		if req.GetTargetPath() != "" {
+			exists, err := checkTargetExists(req.GetTargetPath())
 			if err != nil {
 				return nil, status.Error(codes.Internal, err.Error())
 			}
 			if !exists {
-				status.Errorf(codes.Internal, "staging target path %s does not exist", req.GetStagingTargetPath())
+				// If target path does not exist we need to create the directory where volume will be staged
+				if err = os.Mkdir(req.TargetPath, os.FileMode(0755)); err != nil {
+					msg := fmt.Sprintf("NodePublishVolume: could not create target dir %q: %v", req.TargetPath, err)
+					return nil, status.Error(codes.Internal, msg)
+				}
 			}
-			v.VolumeContext[nodeMntPathKey] = req.GetStagingTargetPath()
+			v.VolumeContext[nodeMntPathKey] = req.GetTargetPath()
 		} else {
 			v.VolumeContext[nodeMntPathKey] = device
 		}
@@ -258,6 +262,12 @@ func (s *service) NodeUnpublishVolume(
 		// Check to see if the volume has already been unpublished.
 		if v.VolumeContext[nodeMntPathKey] == "" {
 			return &csi.NodeUnpublishVolumeResponse{}, nil
+		}
+
+		// Delete any created paths
+		err := os.RemoveAll(v.VolumeContext[nodeMntPathKey])
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Unable to delete previously created target directory")
 		}
 
 		// Unpublish the volume.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
After https://github.com/kubernetes/kubernetes/pull/88759/files we need to create the staging and target directories if they don't exist.

**Which issue(s) this PR fixes**:
Fixes #304

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Updates the mock driver to create the target directory in `NodePublishVolume`, and remove it in `NodeUnpublishVolume`.
```
