### PR TITLE
Add kubelet directories to mock driver manifest

### DIFF
--- a/mock/example/deploy/csi-mock-driver-deployment.yaml
+++ b/mock/example/deploy/csi-mock-driver-deployment.yaml
@@ -86,9 +86,11 @@ spec:
           securityContext:
             privileged: true
         - name: mock-driver
-          image: k8s.gcr.io/sig-storage/mock-driver:v3.1.0
+          image: k8s.gcr.io/sig-storage/mock-driver:v4.1.0
           args:
             - "--attach-limit=50"
+            # Required for e2e test log parsing
+            - "--v=5"
           env:
             - name: CSI_ENDPOINT
               value: /csi/csi.sock
@@ -98,6 +100,10 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+            - name: kubelet-pods-dir
+              mountPath: /var/lib/kubelet/pods
+            - name: kubelet-csi-dir
+              mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
       volumes:
         - name: socket-dir
           hostPath:
@@ -107,7 +113,16 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins_registry
             type: Directory
-
+        - name: kubelet-pods-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+            # mock driver doesn't make mounts and therefore doesn't need mount propagation.
+            # mountPropagation: Bidirectional
+        - name: kubelet-csi-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/kubernetes.io/csi
+            type: DirectoryOrCreate
 ---
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver

--- a/mock/service/node.go
+++ b/mock/service/node.go
@@ -67,7 +67,7 @@ func (s *service) NodeStageVolume(
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	if !exists {
-		status.Errorf(codes.Internal, "staging target path %s does not exist", req.StagingTargetPath)
+		return nil, status.Errorf(codes.Internal, "staging target path %s does not exist", req.StagingTargetPath)
 	}
 
 	s.volsRWL.Lock()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
After #303, we need to mount the kubelet pod directory so we can create the target path. Also fix a bug with validating the csi staging directory.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add kubelet pod and csi plugin directories to mock driver manifest
```
