### PR TITLE
release notes for v3.1.2

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,3 +1,8 @@
+# Changelog since v3.1.1
+
+## Bug Fixes
+ - Updates the mock driver to create the target directory in `NodePublishVolume`, and remove it in `NodeUnpublishVolume`. ([#307](https://github.com/kubernetes-csi/csi-test/pull/307), [@msau42](https://github.com/msau42))
+
 # Changelog since v3.1.0
 
 ## Bug Fixes


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

New release needed for https://github.com/kubernetes/kubernetes/pull/95739

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
