### PR TITLE
Enable attachment in mock driver deployment and bump attach limit

### DIFF
--- a/mock/example/deploy/csi-mock-driver-deployment.yaml
+++ b/mock/example/deploy/csi-mock-driver-deployment.yaml
@@ -88,7 +88,7 @@ spec:
         - name: mock-driver
           image: k8s.gcr.io/sig-storage/mock-driver:v3.1.0
           args:
-            - "--disable-attach=true"
+            - "--attach-limit=50"
           env:
             - name: CSI_ENDPOINT
               value: /csi/csi.sock


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR fixes the mock driver deployment manifest (see #318) to enable attaching, and bumps the attachment limit so users can more reliably test attach / detach behavior (for example with the [volume stress test](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/testsuites/volume_stress.go)).

For reference, [attachment is enabled by default, and we only allow 2 volumes attached per node by default](https://github.com/kubernetes-csi/csi-test/blob/44a753566c47af035eee63aa6fd9013e1815dfa5/cmd/mock-driver/main.go#L44,L46).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/sig storage
/assign @Jiawei0227 
/assign @msau42 
