### PR TITLE
sanity: fix copyright header

### DIFF
--- a/pkg/sanity/resources.go
+++ b/pkg/sanity/resources.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Intel Corporation
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sanity/tests.go
+++ b/pkg/sanity/tests.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Intel Corporation
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

`release-tools/verify-boilerplate.sh` complains about these two files.

**Special notes for your reviewer**:

As the original author, Intel employee and because Intel agreed to
transfer copyright I am allowed to mark the code as owned by the
Kubernetes project.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
