### PR TITLE
support node VOLUME_MOUNT_GROUP cap in test

### DIFF
--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -342,6 +342,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 				case csi.NodeServiceCapability_RPC_EXPAND_VOLUME:
 				case csi.NodeServiceCapability_RPC_VOLUME_CONDITION:
 				case csi.NodeServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER:
+				case csi.NodeServiceCapability_RPC_VOLUME_MOUNT_GROUP:
 				default:
 					Fail(fmt.Sprintf("Unknown capability: %v\n", cap.GetRpc().GetType()))
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
support node VOLUME_MOUNT_GROUP cap, this is a new node capability added in CSI v1.5.0 spec


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
support node VOLUME_MOUNT_GROUP cap in test
```
