### PR TITLE
feat(ListSnapshotsSecret): csi-sanity test suite now passes secrets to ListSnapshots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ We have full documentation on how to get started contributing here:
 
 - [Contributor License Agreement](https://git.k8s.io/community/CLA.md) Kubernetes projects require that you sign a Contributor License Agreement (CLA) before we can accept your pull requests
 - [Kubernetes Contributor Guide](http://git.k8s.io/community/contributors/guide) - Main contributor documentation, or you can just jump directly to the [contributing section](http://git.k8s.io/community/contributors/guide#contributing)
-- [Contributor Cheat Sheet](https://git.k8s.io/community/contributors/guide/contributor-cheatsheet.md) - Common resources for existing developers
+- [Contributor Cheat Sheet](https://github.com/kubernetes/community/blob/master/contributors/guide/contributor-cheatsheet/README.md) - Common resources for existing developers
 
 ## Mentorship
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -65,6 +65,7 @@ type CSICreds struct {
 	CreateSnapshotSecret                       string
 	DeleteSnapshotSecret                       string
 	ControllerValidateVolumeCapabilitiesSecret string
+	ListSnapshotsSecret                        string
 }
 
 type CSIDriver struct {
@@ -184,6 +185,7 @@ func setDefaultCreds(creds *CSICreds) {
 		CreateSnapshotSecret:                       "secretval7",
 		DeleteSnapshotSecret:                       "secretval8",
 		ControllerValidateVolumeCapabilitiesSecret: "secretval9",
+		ListSnapshotsSecret:                        "secretval10",
 	}
 }
 
@@ -262,6 +264,8 @@ func isAuthenticated(req interface{}, creds *CSICreds) (bool, error) {
 		return authenticateDeleteSnapshot(r, creds)
 	case *csi.ValidateVolumeCapabilitiesRequest:
 		return authenticateControllerValidateVolumeCapabilities(r, creds)
+	case *csi.ListSnapshotsRequest:
+		return authenticateListSnapshots(r, creds)
 	default:
 		return true, nil
 	}
@@ -301,6 +305,10 @@ func authenticateDeleteSnapshot(req *csi.DeleteSnapshotRequest, creds *CSICreds)
 
 func authenticateControllerValidateVolumeCapabilities(req *csi.ValidateVolumeCapabilitiesRequest, creds *CSICreds) (bool, error) {
 	return credsCheck(req.GetSecrets(), creds.ControllerValidateVolumeCapabilitiesSecret)
+}
+
+func authenticateListSnapshots(req *csi.ListSnapshotsRequest, creds *CSICreds) (bool, error) {
+	return credsCheck(req.GetSecrets(), creds.ListSnapshotsSecret)
 }
 
 func credsCheck(secrets map[string]string, secretVal string) (bool, error) {

--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -1113,9 +1113,14 @@ var _ = DescribeSanity("ListSnapshots [Controller Server]", func(sc *TestContext
 	})
 
 	It("should return appropriate values (no optional values added)", func() {
-		snapshots, err := r.ListSnapshots(
-			context.Background(),
-			&csi.ListSnapshotsRequest{})
+
+		req := &csi.ListSnapshotsRequest{}
+
+		if sc.Secrets != nil {
+			req.Secrets = sc.Secrets.ListSnapshotsSecret
+		}
+
+		snapshots, err := r.ListSnapshots(context.Background(), req)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(snapshots).NotTo(BeNil())
 
@@ -1145,9 +1150,14 @@ var _ = DescribeSanity("ListSnapshots [Controller Server]", func(sc *TestContext
 		r.MustCreateSnapshotFromVolumeRequest(context.Background(), volReq, "listSnapshots-snapshot-unrelated2")
 
 		By("listing snapshots")
-		snapshots, err := r.ListSnapshots(
-			context.Background(),
-			&csi.ListSnapshotsRequest{SnapshotId: snapshotTarget.GetSnapshot().GetSnapshotId()})
+
+		req := &csi.ListSnapshotsRequest{SnapshotId: snapshotTarget.GetSnapshot().GetSnapshotId()}
+
+		if sc.Secrets != nil {
+			req.Secrets = sc.Secrets.ListSnapshotsSecret
+		}
+
+		snapshots, err := r.ListSnapshots(context.Background(), req)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(snapshots).NotTo(BeNil())
 		Expect(snapshots.GetEntries()).To(HaveLen(1))
@@ -1157,9 +1167,13 @@ var _ = DescribeSanity("ListSnapshots [Controller Server]", func(sc *TestContext
 
 	It("should return empty when the specified snapshot id does not exist", func() {
 
-		snapshots, err := r.ListSnapshots(
-			context.Background(),
-			&csi.ListSnapshotsRequest{SnapshotId: "none-exist-id"})
+		req := &csi.ListSnapshotsRequest{SnapshotId: "none-exist-id"}
+
+		if sc.Secrets != nil {
+			req.Secrets = sc.Secrets.ListSnapshotsSecret
+		}
+
+		snapshots, err := r.ListSnapshots(context.Background(), req)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(snapshots).NotTo(BeNil())
 		Expect(snapshots.GetEntries()).To(BeEmpty())
@@ -1187,9 +1201,14 @@ var _ = DescribeSanity("ListSnapshots [Controller Server]", func(sc *TestContext
 		r.MustCreateSnapshotFromVolumeRequest(context.Background(), volReq, "listSnapshots-snapshot-unrelated2")
 
 		By("listing snapshots")
-		snapshots, err := r.ListSnapshots(
-			context.Background(),
-			&csi.ListSnapshotsRequest{SourceVolumeId: snapshotTarget.GetSnapshot().GetSourceVolumeId()})
+
+		req := &csi.ListSnapshotsRequest{SourceVolumeId: snapshotTarget.GetSnapshot().GetSourceVolumeId()}
+
+		if sc.Secrets != nil {
+			req.Secrets = sc.Secrets.ListSnapshotsSecret
+		}
+
+		snapshots, err := r.ListSnapshots(context.Background(), req)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(snapshots).NotTo(BeNil())
 		Expect(snapshots.GetEntries()).To(HaveLen(1))
@@ -1200,9 +1219,13 @@ var _ = DescribeSanity("ListSnapshots [Controller Server]", func(sc *TestContext
 
 	It("should return empty when the specified source volume id does not exist", func() {
 
-		snapshots, err := r.ListSnapshots(
-			context.Background(),
-			&csi.ListSnapshotsRequest{SourceVolumeId: sc.Config.IDGen.GenerateUniqueValidVolumeID()})
+		req := &csi.ListSnapshotsRequest{SourceVolumeId: sc.Config.IDGen.GenerateUniqueValidVolumeID()}
+
+		if sc.Secrets != nil {
+			req.Secrets = sc.Secrets.ListSnapshotsSecret
+		}
+
+		snapshots, err := r.ListSnapshots(context.Background(), req)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(snapshots).NotTo(BeNil())
 		Expect(snapshots.GetEntries()).To(BeEmpty())
@@ -1210,9 +1233,14 @@ var _ = DescribeSanity("ListSnapshots [Controller Server]", func(sc *TestContext
 
 	It("check the presence of new snapshots in the snapshot list", func() {
 		// List Snapshots before creating new snapshots.
-		snapshots, err := r.ListSnapshots(
-			context.Background(),
-			&csi.ListSnapshotsRequest{})
+
+		req := &csi.ListSnapshotsRequest{}
+
+		if sc.Secrets != nil {
+			req.Secrets = sc.Secrets.ListSnapshotsSecret
+		}
+
+		snapshots, err := r.ListSnapshots(context.Background(), req)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(snapshots).NotTo(BeNil())
 
@@ -1223,21 +1251,21 @@ var _ = DescribeSanity("ListSnapshots [Controller Server]", func(sc *TestContext
 		snapshot, _ := r.MustCreateSnapshotFromVolumeRequest(context.Background(), volReq, "listSnapshots-snapshot-3")
 		verifySnapshotInfo(snapshot.GetSnapshot())
 
-		snapshots, err = r.ListSnapshots(
-			context.Background(),
-			&csi.ListSnapshotsRequest{})
+		snapshots, err = r.ListSnapshots(context.Background(), req)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(snapshots).NotTo(BeNil())
 		Expect(snapshots.GetEntries()).To(HaveLen(totalSnapshots + 1))
 
 		By("deleting the snapshot")
-		_, err = r.DeleteSnapshot(context.Background(), &csi.DeleteSnapshotRequest{SnapshotId: snapshot.Snapshot.SnapshotId})
+		dreq := &csi.DeleteSnapshotRequest{SnapshotId: snapshot.Snapshot.SnapshotId}
+		if sc.Secrets != nil {
+			dreq.Secrets = sc.Secrets.DeleteSnapshotSecret
+		}
+		_, err = r.DeleteSnapshot(context.Background(), dreq)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("checking if deleted snapshot is omitted")
-		snapshots, err = r.ListSnapshots(
-			context.Background(),
-			&csi.ListSnapshotsRequest{})
+		snapshots, err = r.ListSnapshots(context.Background(), req)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(snapshots).NotTo(BeNil())
 		Expect(snapshots.GetEntries()).To(HaveLen(totalSnapshots))
@@ -1253,10 +1281,14 @@ var _ = DescribeSanity("ListSnapshots [Controller Server]", func(sc *TestContext
 		// is used to verify that all the snapshots have been listed.
 		currentTotalSnapshots := 0
 
+		req := &csi.ListSnapshotsRequest{}
+
+		if sc.Secrets != nil {
+			req.Secrets = sc.Secrets.ListSnapshotsSecret
+		}
+
 		// Get the number of existing volumes.
-		snapshots, err := r.ListSnapshots(
-			context.Background(),
-			&csi.ListSnapshotsRequest{})
+		snapshots, err := r.ListSnapshots(context.Background(), req)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(snapshots).NotTo(BeNil())
 
@@ -1280,11 +1312,14 @@ var _ = DescribeSanity("ListSnapshots [Controller Server]", func(sc *TestContext
 		}
 
 		// Request list snapshots with max entries maxEntries.
-		snapshots, err = r.ListSnapshots(
-			context.Background(),
-			&csi.ListSnapshotsRequest{
-				MaxEntries: int32(maxEntries),
-			})
+
+		req = &csi.ListSnapshotsRequest{MaxEntries: int32(maxEntries)}
+
+		if sc.Secrets != nil {
+			req.Secrets = sc.Secrets.ListSnapshotsSecret
+		}
+
+		snapshots, err = r.ListSnapshots(context.Background(), req)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(snapshots).NotTo(BeNil())
 
@@ -1293,11 +1328,14 @@ var _ = DescribeSanity("ListSnapshots [Controller Server]", func(sc *TestContext
 		Expect(snapshots.GetEntries()).To(HaveLen(maxEntries))
 
 		// Request list snapshots with starting_token and no max entries.
-		snapshots, err = r.ListSnapshots(
-			context.Background(),
-			&csi.ListSnapshotsRequest{
-				StartingToken: nextToken,
-			})
+
+		req = &csi.ListSnapshotsRequest{StartingToken: nextToken}
+
+		if sc.Secrets != nil {
+			req.Secrets = sc.Secrets.ListSnapshotsSecret
+		}
+
+		snapshots, err = r.ListSnapshots(context.Background(), req)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(snapshots).NotTo(BeNil())
 

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -48,6 +48,7 @@ type CSISecrets struct {
 	CreateSnapshotSecret                       map[string]string `yaml:"CreateSnapshotSecret"`
 	DeleteSnapshotSecret                       map[string]string `yaml:"DeleteSnapshotSecret"`
 	ControllerExpandVolumeSecret               map[string]string `yaml:"ControllerExpandVolumeSecret"`
+	ListSnapshotsSecret                        map[string]string `yaml:"ListSnapshotsSecret"`
 }
 
 // TestConfig provides the configuration for the sanity tests. It must be


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds ListSnapshotsSecret handling to the csi-sanity test suite. This feature is needed by CSI Drivers that require secrets in order to execute the Controller ListSnapshots function. All csi-sanity calls to ListSnapshot now pass in ListSnapshotsSecret.

**Which issue(s) this PR fixes**:
Fixes #356

**Special notes for your reviewer**:
- Small change to correct link in CONTRIBUTING.md
- CSICreds now includes ListSnapshotsSecret
- Adjusted ListSnapshotRequest objects to include sc.Secrets.ListSnapshotsSecret
- Also passing sc.Secrets.DeleteSnapshotSecret to the 'deleting the snapshot' call (separate issue)

**Does this PR introduce a user-facing change?**:
```release-note
Users will need to add ListSnapshotsSecret to a YAML file to pass secrets to the CSI Driver in from the csi-sanity -csi.secrets ${secrets} ... call.
```
