### PR TITLE
add ControllerPublishSupported

### DIFF
--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -310,11 +310,9 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 		nodeExpansionSupported = isNodeCapabilitySupported(n, csi.NodeServiceCapability_RPC_EXPAND_VOLUME)
 		controllerExpansionSupported = isControllerCapabilitySupported(cl, csi.ControllerServiceCapability_RPC_EXPAND_VOLUME)
 		r = &Resources{
-			Context:                    sc,
-			ControllerClient:           cl,
-			NodeClient:                 n,
-			ControllerPublishSupported: controllerPublishSupported,
-			NodeStageSupported:         nodeStageSupported,
+			Context:          sc,
+			ControllerClient: cl,
+			NodeClient:       n,
 		}
 	})
 

--- a/pkg/sanity/resources.go
+++ b/pkg/sanity/resources.go
@@ -65,8 +65,6 @@ type Resources struct {
 	// directly if automatic cleanup is not desired and cannot be avoided
 	// otherwise.
 	csi.NodeClient
-	ControllerPublishSupported bool
-	NodeStageSupported         bool
 
 	// mutex protects access to managedResourceInfos.
 	mutex                sync.Mutex
@@ -279,7 +277,7 @@ func (cl *Resources) cleanupVolume(ctx context.Context, offset int, volumeID str
 			errs = append(errs, fmt.Errorf("NodeUnpublishVolume for volume ID %s failed: %s", volumeID, err))
 		}
 
-		if cl.NodeStageSupported {
+		if isNodeCapabilitySupported(cl, csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME) {
 			if _, err := cl.NodeUnstageVolume(
 				ctx,
 				&csi.NodeUnstageVolumeRequest{
@@ -292,7 +290,7 @@ func (cl *Resources) cleanupVolume(ctx context.Context, offset int, volumeID str
 		}
 	}
 
-	if cl.ControllerPublishSupported && info.NodeID != "" {
+	if info.NodeID != "" {
 		if _, err := cl.ControllerClient.ControllerUnpublishVolume(
 			ctx,
 			&csi.ControllerUnpublishVolumeRequest{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

The lack of `ControllerPublishSupported` in `Resources` cause [this line](https://github.com/kubernetes-csi/csi-test/blob/da7a71c90b602694a44815fc4c3533e803601b87/pkg/sanity/resources.go#L295) to always return false.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: Fixes #316
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #316

**Special notes for your reviewer**:
if you see a more elegant way to enter the `ControllerPublishSupported` into `Resources` please feel free to fix it.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
