### PR TITLE
GitHub: enable dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  labels:
+    - "area/dependency"
+    - "release-note-none"
+    - "ok-to-test"
+  open-pull-requests-limit: 10
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+      interval: "daily"
+  labels:
+    - "area/dependency"
+    - "release-note-none"
+    - "ok-to-test"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Automatically updating dependencies saves on manual labor. The PRs created by
the bot are also more informative.

k8s.io packages are excluded. At least the staging repos don't have API
stability guarantees and better should get updated manually.

**Special notes for your reviewer**:

This was copied from
https://github.com/intel/intel-device-plugins-for-kubernetes/blob/faaecec537516a71c25f4af1e42d03aca2053a87/.github/dependabot.yml#L1-L16

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @xing-yang 