### PR TITLE
.prow.sh: remove hard-coded Kubernetes version

### DIFF
--- a/.prow.sh
+++ b/.prow.sh
@@ -18,13 +18,6 @@
 # Only these tests make sense for csi-sanity.
 : ${CSI_PROW_TESTS:="unit sanity"}
 
-# What matters for csi-sanity is the version of the hostpath driver
-# that we test against, not the version of Kubernetes that it runs on.
-# We pick the latest stable Kubernetes here because the corresponding
-# deployment has the current driver. v1.0.1 (from the current 1.13
-# deployment) does not pass csi-sanity testing.
-: ${CSI_PROW_KUBERNETES_VERSION:=1.17.0}
-
 # This repo supports and wants sanity testing.
 CSI_PROW_TESTS_SANITY=sanity
 


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:

The rationale was partly flawed: not all driver versions are compatible with
all Kubernetes versions. For example, the current csi-driver-host-path v1.8.0
uses the v1 CSIDriver API and thus no longer installs in Kubernetes 1.17.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
