### PR TITLE
fix: PluginCapability can be nil

### DIFF
--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -94,7 +94,6 @@ func isControllerCapabilitySupported(
 		&csi.ControllerGetCapabilitiesRequest{})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(caps).NotTo(BeNil())
-	Expect(caps.GetCapabilities()).NotTo(BeNil())
 
 	for _, cap := range caps.GetCapabilities() {
 		Expect(cap.GetRpc()).NotTo(BeNil())

--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -56,7 +56,6 @@ func isPluginCapabilitySupported(c csi.IdentityClient,
 		context.Background(),
 		&csi.GetPluginCapabilitiesRequest{})
 	Expect(err).NotTo(HaveOccurred())
-	Expect(caps).NotTo(BeNil())
 
 	for _, cap := range caps.GetCapabilities() {
 		if cap.GetService() != nil && cap.GetService().GetType() == capType {
@@ -290,7 +289,6 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 		req := &csi.GetPluginCapabilitiesRequest{}
 		res, err := i.GetPluginCapabilities(context.Background(), req)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(res).NotTo(BeNil())
 		for _, cap := range res.GetCapabilities() {
 			switch cap.GetType().(type) {
 			case *csi.PluginCapability_Service_:


### PR DESCRIPTION
In [GetPluginCapabilities](https://github.com/container-storage-interface/spec/blob/master/spec.md#getplugincapabilities) PluginCapability is optional

Signed-off-by: Guilhem Lettron <guilhem@barpilot.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

When plugin doesn't implement controller nor accessibility, tests are failing

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
