### PR TITLE
Assert NodePublishVolume behavior for single node single writer volumes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ build-sanity:
 	$(MAKE) -C cmd/csi-sanity all
 
 
-TEST_HOSTPATH_VERSION=v1.7.3
+TEST_HOSTPATH_VERSION=v1.11.0
 TEST_HOSTPATH_SOURCE=bin/hostpath-source
 TEST_HOSTPATH_REPO=https://github.com/kubernetes-csi/csi-driver-host-path.git
 bin/hostpathplugin:

--- a/hack/_apitest2/api_test.go
+++ b/hack/_apitest2/api_test.go
@@ -31,10 +31,10 @@ func TestMyDriverWithCustomTargetPaths(t *testing.T) {
 	var createTargetDirCalls, createStagingDirCalls,
 		removeTargetDirCalls, removeStagingDirCalls int
 
-	wantCreateTargetCalls := 3
-	wantCreateStagingCalls := 3
-	wantRemoveTargetCalls := 3
-	wantRemoveStagingCalls := 3
+	wantCreateTargetCalls := 4
+	wantCreateStagingCalls := 4
+	wantRemoveTargetCalls := 4
+	wantRemoveStagingCalls := 4
 
 	// tmpPath could be a CO specific directory under which all the target dirs
 	// are created. For k8s, it could be /var/lib/kubelet/pods under which the


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds a test case that asserts `SINGLE_NODE_SINGLE_WRITER` volumes can only be published at one target path on a node.

**Which issue(s) this PR fixes**:
Fixes #420

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Add node publish volume test for volume with SINGLE_NODE_SINGLE_WRITER access mode
```