### PR TITLE
Update release tools

### DIFF
--- a/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
+++ b/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
@@ -22,16 +22,19 @@ aliases:
   - ggriffiths
   - gnufied
   - humblec
+  - mauriciopoppe
   - j-griffith
-  - Jiawei0227
   - jingxu97
   - jsafrane
   - pohly
+  - RaunakShah
+  - sunnylovestiramisu
   - xing-yang
 
 # This documents who previously contributed to Kubernetes-CSI
 # as approver.
 emeritus_approvers:
+- Jiawei0227
 - lpabon
 - sbezverk
 - vladimirvivien

--- a/release-tools/SIDECAR_RELEASE_PROCESS.md
+++ b/release-tools/SIDECAR_RELEASE_PROCESS.md
@@ -92,6 +92,8 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 1. Check that all [canary CI
   jobs](https://k8s-testgrid.appspot.com/sig-storage-csi-ci) are passing,
   and that test coverage is adequate for the changes that are going into the release.
+1. Check that the post-\<sidecar\>-push-images builds are succeeding.
+   [Example](https://k8s-testgrid.appspot.com/sig-storage-image-build#post-external-snapshotter-push-images)
 1. Make sure that no new PRs have merged in the meantime, and no PRs are in
    flight and soon to be merged.
 1. Create a new release following a previous release as a template. Be sure to select the correct

--- a/release-tools/filter-junit.go
+++ b/release-tools/filter-junit.go
@@ -56,6 +56,7 @@ type TestCase struct {
 	Name      string     `xml:"name,attr"`
 	Time      string     `xml:"time,attr"`
 	SystemOut string     `xml:"system-out,omitempty"`
+	SystemErr string     `xml:"system-err,omitempty"`
 	Failure   string     `xml:"failure,omitempty"`
 	Skipped   SkipReason `xml:"skipped,omitempty"`
 }
@@ -109,7 +110,7 @@ func main() {
 			if err := xml.Unmarshal(data, &junitv2); err != nil {
 				panic(err)
 			}
-			junit = junitv2.TestSuite
+			junit.TestCases = append(junit.TestCases, junitv2.TestSuite.TestCases...)
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
Squashed 'release-tools/' changes from d24254f..aa61bfd

[aa61bfd](https://github.com/kubernetes-csi/csi-release-tools/commit/aa61bfd) Merge [pull request #218](https://github.com/kubernetes-csi/csi-release-tools/pull/218) from xing-yang/update_csi_driver
[7563d19](https://github.com/kubernetes-csi/csi-release-tools/commit/7563d19) Update CSI_PROW_DRIVER_VERSION to v1.11.0
[a2171be](https://github.com/kubernetes-csi/csi-release-tools/commit/a2171be) Merge [pull request #216](https://github.com/kubernetes-csi/csi-release-tools/pull/216) from msau42/process
[cb98782](https://github.com/kubernetes-csi/csi-release-tools/commit/cb98782) Merge [pull request #217](https://github.com/kubernetes-csi/csi-release-tools/pull/217) from msau42/owners
[a11216e](https://github.com/kubernetes-csi/csi-release-tools/commit/a11216e) add new reviewers and remove inactive reviewers
[dd98675](https://github.com/kubernetes-csi/csi-release-tools/commit/dd98675) Add step for checking builds
[b66c082](https://github.com/kubernetes-csi/csi-release-tools/commit/b66c082) Merge [pull request #214](https://github.com/kubernetes-csi/csi-release-tools/pull/214) from pohly/junit-fixes
[b9b6763](https://github.com/kubernetes-csi/csi-release-tools/commit/b9b6763) filter-junit.go: fix loss of testcases when parsing Ginkgo v2 JUnit
[d427783](https://github.com/kubernetes-csi/csi-release-tools/commit/d427783) filter-junit.go: preserve system error log
[38e1146](https://github.com/kubernetes-csi/csi-release-tools/commit/38e1146) prow.sh: publish individual JUnit files as separate artifacts
[78c0fb7](https://github.com/kubernetes-csi/csi-release-tools/commit/78c0fb7) Merge [pull request #208](https://github.com/kubernetes-csi/csi-release-tools/pull/208) from jsafrane/skip-selinux
[36e433e](https://github.com/kubernetes-csi/csi-release-tools/commit/36e433e) Skip SELinux tests in CI by default
[348d4a9](https://github.com/kubernetes-csi/csi-release-tools/commit/348d4a9) Merge [pull request #207](https://github.com/kubernetes-csi/csi-release-tools/pull/207) from RaunakShah/reviewers
[1efc272](https://github.com/kubernetes-csi/csi-release-tools/commit/1efc272) Merge [pull request #206](https://github.com/kubernetes-csi/csi-release-tools/pull/206) from RaunakShah/update-prow
[7d410d8](https://github.com/kubernetes-csi/csi-release-tools/commit/7d410d8) Changes to csi prow to run e2e tests in sidecars
[cfa5a75](https://github.com/kubernetes-csi/csi-release-tools/commit/cfa5a75) Merge [pull request #203](https://github.com/kubernetes-csi/csi-release-tools/pull/203) from humblec/test-vendor
[4edd1d8](https://github.com/kubernetes-csi/csi-release-tools/commit/4edd1d8) Add RaunakShah to CSI reviewers group
[7ccc959](https://github.com/kubernetes-csi/csi-release-tools/commit/7ccc959) release tools update to 1.19

git-subtree-dir: release-tools
git-subtree-split: aa61bfd0c1a80460aba7cb0feddc8cdee03622a4


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

@jsafrane
@msau42 