### PR TITLE
Allow drivers to support the GROUP_CONTROLLER_SERVICE capability

### DIFF
--- a/pkg/sanity/identity.go
+++ b/pkg/sanity/identity.go
@@ -53,6 +53,7 @@ var _ = DescribeSanity("Identity Service", func(sc *TestContext) {
 					switch cap.GetService().GetType() {
 					case csi.PluginCapability_Service_CONTROLLER_SERVICE:
 					case csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS:
+					case csi.PluginCapability_Service_GROUP_CONTROLLER_SERVICE:
 					default:
 						Fail(fmt.Sprintf("Unknown service: %v\n", cap.GetService().GetType()))
 					}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

The external-snapshotter is going to support [Volume Group Snapshot](kubernetes/enhancements#1551), so drivers will return the capability as well.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

There are no tests for the new Volume Group Snapshot yet. kubernetes-csi/csi-driver-host-path#399 is the first PR for a driver to support the new ALPHA feature.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
