### PR TITLE
Add grpc authority to more closely resemble Kubernetes behaviour

### DIFF
--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -199,8 +199,8 @@ func NewTestConfig() TestConfig {
 		IdempotentCount:      10,
 		CheckPathCmdTimeout:  10 * time.Second,
 
-		DialOptions:           []grpc.DialOption{grpc.WithInsecure()},
-		ControllerDialOptions: []grpc.DialOption{grpc.WithInsecure()},
+		DialOptions:           []grpc.DialOption{grpc.WithInsecure(), grpc.WithAuthority("localhost")},
+		ControllerDialOptions: []grpc.DialOption{grpc.WithInsecure(), grpc.WithAuthority("localhost")},
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR adds a "localhost" authority to the grpc unix-socket connection to more closely resemble Kubernetes real behaviour after: https://github.com/kubernetes/kubernetes/pull/112597 in which it was introduced

**Which issue(s) this PR fixes**:
There are currently no open issues regarding this

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
NONE

```release-note
Set the grpc authority to "localhost" to mimic Kubernetes behaviour
```
