### PR TITLE
Check ContentSource when creating volume from snapshot

### DIFF
--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -588,7 +588,8 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 					},
 				},
 			}
-			_, err := r.CreateVolume(context.Background(), vol2Req)
+			vol, err := r.CreateVolume(context.Background(), vol2Req)
+			Expect(vol.GetVolume().ContentSource).NotTo(BeNil())
 			Expect(err).NotTo(HaveOccurred())
 		})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind flake

/kind feature

**What this PR does / why we need it**:

When developing our CSI, the volumes being created from snapshots were being deleted automatically, because the response wasn't including `ContentSource` information. Sanity tests were passing in our environment, and it was confusing to see that the tests were testing this particular case (creating a volume from snapshot) and the result was successful.

This commit made the sanity tests in our end fail with our CSI issue.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added check to ensure ContentSource is set when creating a volume from a snapshot.
```
