### PR TITLE
Add VolumeContext in ControllerPublishVolume

### DIFF
--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -1721,6 +1721,7 @@ func VolumeLifecycle(r *Resources, sc *TestContext, count int) {
 				VolumeId:         vol.GetVolume().GetVolumeId(),
 				NodeId:           ni.GetNodeId(),
 				VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+				VolumeContext:    vol.GetVolume().GetVolumeContext(),
 				Readonly:         false,
 				Secrets:          sc.Secrets.ControllerPublishVolumeSecret,
 			},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Currently the VolumeContext is not populated in the ControllerPublishVolume request in the volume lifecycle tests. With this change we add the VolumeContext similar to as we do in the NodePublishVolume.

```release-note
NONE
```
