### PR TITLE
Add ControllerModifyVolume RPC sanity tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 
 #ignore files specific to csi-test
-bin/mock-driver
+bin/*
 cmd/csi-sanity/csi-sanity

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ build-sanity:
 	$(MAKE) -C cmd/csi-sanity all
 
 
-TEST_HOSTPATH_VERSION=v1.7.3
+TEST_HOSTPATH_VERSION=v1.14.1
 TEST_HOSTPATH_SOURCE=bin/hostpath-source
 TEST_HOSTPATH_REPO=https://github.com/kubernetes-csi/csi-driver-host-path.git
 bin/hostpathplugin:

--- a/cmd/csi-sanity/main.go
+++ b/cmd/csi-sanity/main.go
@@ -88,6 +88,7 @@ func main() {
 	int64Var(&config.TestVolumeSize, "testvolumesize", "Base volume size used for provisioned volumes")
 	int64Var(&config.TestVolumeExpandSize, "testvolumeexpandsize", "Target size for expanded volumes")
 	stringVar(&config.TestVolumeParametersFile, "testvolumeparameters", "YAML file of volume parameters for provisioned volumes")
+	stringVar(&config.TestVolumeMutableParametersFile, "testvolumemutableparameters", "YAML file of mutable parameters for modifying volumes")
 	stringVar(&config.TestSnapshotParametersFile, "testsnapshotparameters", "YAML file of snapshot parameters for provisioned snapshots")
 	boolVar(&config.TestNodeVolumeAttachLimit, "testnodevolumeattachlimit", "Test node volume attach limit")
 	flag.Var(flag.Lookup("ginkgo.junit-report").Value, prefix+"junitfile", "JUnit XML output file where test results will be written (deprecated: use ginkgo.junit-report instead)")

--- a/pkg/sanity/groupcontroller.go
+++ b/pkg/sanity/groupcontroller.go
@@ -20,10 +20,8 @@ import (
 	"context"
 	"fmt"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -156,64 +154,48 @@ var _ = DescribeSanity("GroupController Service [GroupController VolumeGroupSnap
 
 	Describe("CreateVolumeGroupSnapshot", func() {
 		It("should fail when no name is provided", func() {
-			_, err := r.CreateVolumeGroupSnapshot(
+			rsp, err := r.CreateVolumeGroupSnapshot(
 				context.Background(),
 				&csi.CreateVolumeGroupSnapshotRequest{
 					Secrets: sc.Secrets.CreateSnapshotSecret,
 				},
 			)
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.InvalidArgument), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.InvalidArgument)
 		})
 	})
 
 	Describe("GetVolumeGroupSnapshot", func() {
 		It("should fail when no volume id is provided", func() {
-			_, err := r.GetVolumeGroupSnapshot(
+			rsp, err := r.GetVolumeGroupSnapshot(
 				context.Background(),
 				&csi.GetVolumeGroupSnapshotRequest{
 					Secrets: sc.Secrets.ListSnapshotsSecret,
 				},
 			)
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.InvalidArgument), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.InvalidArgument)
 		})
 
 		It("should fail when an invalid volume id is used", func() {
-			_, err := r.GetVolumeGroupSnapshot(
+			rsp, err := r.GetVolumeGroupSnapshot(
 				context.Background(),
 				&csi.GetVolumeGroupSnapshotRequest{
 					GroupSnapshotId: sc.Config.IDGen.GenerateInvalidVolumeID(),
 					Secrets:         sc.Secrets.ListSnapshotsSecret,
 				},
 			)
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.NotFound), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.NotFound)
 		})
 	})
 
 	Describe("DeleteVolumeGroupSnapshot", func() {
 		It("should fail when no volume id is provided", func() {
-			_, err := r.DeleteVolumeGroupSnapshot(
+			rsp, err := r.DeleteVolumeGroupSnapshot(
 				context.Background(),
 				&csi.DeleteVolumeGroupSnapshotRequest{
 					Secrets: sc.Secrets.DeleteSnapshotSecret,
 				},
 			)
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.InvalidArgument), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.InvalidArgument)
 		})
 
 		It("should succeed when an invalid volume id is used", func() {

--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -20,10 +20,8 @@ import (
 	"context"
 	"fmt"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -377,36 +375,28 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 
 	Describe("NodePublishVolume", func() {
 		It("should fail when no volume id is provided", func() {
-			_, err := r.NodePublishVolume(
+			rsp, err := r.NodePublishVolume(
 				context.Background(),
 				&csi.NodePublishVolumeRequest{
 					Secrets: sc.Secrets.NodePublishVolumeSecret,
 				},
 			)
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.InvalidArgument), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.InvalidArgument)
 		})
 
 		It("should fail when no target path is provided", func() {
-			_, err := r.NodePublishVolume(
+			rsp, err := r.NodePublishVolume(
 				context.Background(),
 				&csi.NodePublishVolumeRequest{
 					VolumeId: sc.Config.IDGen.GenerateUniqueValidVolumeID(),
 					Secrets:  sc.Secrets.NodePublishVolumeSecret,
 				},
 			)
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.InvalidArgument), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.InvalidArgument)
 		})
 
 		It("should fail when no volume capability is provided", func() {
-			_, err := r.NodePublishVolume(
+			rsp, err := r.NodePublishVolume(
 				context.Background(),
 				&csi.NodePublishVolumeRequest{
 					VolumeId:         sc.Config.IDGen.GenerateUniqueValidVolumeID(),
@@ -415,39 +405,27 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 					Secrets:          sc.Secrets.NodePublishVolumeSecret,
 				},
 			)
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.InvalidArgument), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.InvalidArgument)
 		})
 	})
 
 	Describe("NodeUnpublishVolume", func() {
 		It("should fail when no volume id is provided", func() {
 
-			_, err := r.NodeUnpublishVolume(
+			rsp, err := r.NodeUnpublishVolume(
 				context.Background(),
 				&csi.NodeUnpublishVolumeRequest{})
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.InvalidArgument), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.InvalidArgument)
 		})
 
 		It("should fail when no target path is provided", func() {
 
-			_, err := r.NodeUnpublishVolume(
+			rsp, err := r.NodeUnpublishVolume(
 				context.Background(),
 				&csi.NodeUnpublishVolumeRequest{
 					VolumeId: sc.Config.IDGen.GenerateUniqueValidVolumeID(),
 				})
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.InvalidArgument), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.InvalidArgument)
 		})
 
 		It("should remove target path", func() {
@@ -523,7 +501,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 		})
 
 		It("should fail when no volume id is provided", func() {
-			_, err := r.NodeStageVolume(
+			rsp, err := r.NodeStageVolume(
 				context.Background(),
 				&csi.NodeStageVolumeRequest{
 					StagingTargetPath: sc.StagingPath,
@@ -534,15 +512,11 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 					Secrets: sc.Secrets.NodeStageVolumeSecret,
 				},
 			)
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.InvalidArgument), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.InvalidArgument)
 		})
 
 		It("should fail when no staging target path is provided", func() {
-			_, err := r.NodeStageVolume(
+			rsp, err := r.NodeStageVolume(
 				context.Background(),
 				&csi.NodeStageVolumeRequest{
 					VolumeId:         sc.Config.IDGen.GenerateUniqueValidVolumeID(),
@@ -553,11 +527,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 					Secrets: sc.Secrets.NodeStageVolumeSecret,
 				},
 			)
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.InvalidArgument), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.InvalidArgument)
 		})
 
 		It("should fail when no volume capability is provided", func() {
@@ -585,7 +555,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 				},
 			)
 
-			_, err := r.NodeStageVolume(
+			rsp, err := r.NodeStageVolume(
 				context.Background(),
 				&csi.NodeStageVolumeRequest{
 					VolumeId:          vol.GetVolume().GetVolumeId(),
@@ -596,11 +566,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 					Secrets: sc.Secrets.NodeStageVolumeSecret,
 				},
 			)
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.InvalidArgument), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.InvalidArgument)
 		})
 	})
 
@@ -613,30 +579,22 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 
 		It("should fail when no volume id is provided", func() {
 
-			_, err := r.NodeUnstageVolume(
+			rsp, err := r.NodeUnstageVolume(
 				context.Background(),
 				&csi.NodeUnstageVolumeRequest{
 					StagingTargetPath: sc.StagingPath,
 				})
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.InvalidArgument), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.InvalidArgument)
 		})
 
 		It("should fail when no staging target path is provided", func() {
 
-			_, err := r.NodeUnstageVolume(
+			rsp, err := r.NodeUnstageVolume(
 				context.Background(),
 				&csi.NodeUnstageVolumeRequest{
 					VolumeId: sc.Config.IDGen.GenerateUniqueValidVolumeID(),
 				})
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.InvalidArgument), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.InvalidArgument)
 		})
 	})
 
@@ -648,46 +606,34 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 		})
 
 		It("should fail when no volume id is provided", func() {
-			_, err := r.NodeGetVolumeStats(
+			rsp, err := r.NodeGetVolumeStats(
 				context.Background(),
 				&csi.NodeGetVolumeStatsRequest{
 					VolumePath: "some/path",
 				},
 			)
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.InvalidArgument), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.InvalidArgument)
 		})
 
 		It("should fail when no volume path is provided", func() {
-			_, err := r.NodeGetVolumeStats(
+			rsp, err := r.NodeGetVolumeStats(
 				context.Background(),
 				&csi.NodeGetVolumeStatsRequest{
 					VolumeId: sc.Config.IDGen.GenerateUniqueValidVolumeID(),
 				},
 			)
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.InvalidArgument), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.InvalidArgument)
 		})
 
 		It("should fail when volume is not found", func() {
-			_, err := r.NodeGetVolumeStats(
+			rsp, err := r.NodeGetVolumeStats(
 				context.Background(),
 				&csi.NodeGetVolumeStatsRequest{
 					VolumeId:   sc.Config.IDGen.GenerateUniqueValidVolumeID(),
 					VolumePath: "some/path",
 				},
 			)
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.NotFound), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.NotFound)
 		})
 
 		It("should fail when volume does not exist on the specified path", func() {
@@ -713,18 +659,14 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 
 			// NodeGetVolumeStats
 			By("Get node volume stats")
-			_, err = r.NodeGetVolumeStats(
+			rsp, err := r.NodeGetVolumeStats(
 				context.Background(),
 				&csi.NodeGetVolumeStatsRequest{
 					VolumeId:   vol.GetVolume().GetVolumeId(),
 					VolumePath: "some/path",
 				},
 			)
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.NotFound), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.NotFound)
 		})
 
 	})
@@ -738,18 +680,14 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 		})
 
 		It("should fail when no volume id is provided", func() {
-			_, err := r.NodeExpandVolume(
+			rsp, err := r.NodeExpandVolume(
 				context.Background(),
 				&csi.NodeExpandVolumeRequest{
 					VolumePath:       sc.TargetPath,
 					VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 				},
 			)
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.InvalidArgument), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.InvalidArgument)
 		})
 
 		It("should fail when no volume path is provided", func() {
@@ -757,33 +695,25 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 
 			vol := createVolume(name)
 
-			_, err := r.NodeExpandVolume(
+			rsp, err := r.NodeExpandVolume(
 				context.Background(),
 				&csi.NodeExpandVolumeRequest{
 					VolumeId:         vol.GetVolume().VolumeId,
 					VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 				},
 			)
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.InvalidArgument), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.InvalidArgument)
 		})
 
 		It("should fail when volume is not found", func() {
-			_, err := r.NodeExpandVolume(
+			rsp, err := r.NodeExpandVolume(
 				context.Background(),
 				&csi.NodeExpandVolumeRequest{
 					VolumeId:   sc.Config.IDGen.GenerateUniqueValidVolumeID(),
 					VolumePath: "some/path",
 				},
 			)
-			Expect(err).To(HaveOccurred())
-
-			serverError, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(serverError.Code()).To(Equal(codes.NotFound), "unexpected error: %s", serverError.Message())
+			ExpectErrorCode(rsp, err, codes.NotFound)
 		})
 
 		It("should work if node-expand is called after node-publish", func() {

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -47,6 +47,7 @@ type CSISecrets struct {
 	CreateSnapshotSecret                       map[string]string `yaml:"CreateSnapshotSecret"`
 	DeleteSnapshotSecret                       map[string]string `yaml:"DeleteSnapshotSecret"`
 	ControllerExpandVolumeSecret               map[string]string `yaml:"ControllerExpandVolumeSecret"`
+	ControllerModifyVolumeSecret               map[string]string `yaml:"ControllerModifyVolumeSecret"`
 	ListSnapshotsSecret                        map[string]string `yaml:"ListSnapshotsSecret"`
 }
 
@@ -100,6 +101,10 @@ type TestConfig struct {
 	// TestSnapshotParametersFile for setting CreateVolumeRequest.Parameters.
 	TestSnapshotParametersFile string
 	TestSnapshotParameters     map[string]string
+
+	// TestVolumeMutableParametersFile for setting ModifyVolumeRequest.MutableParameters.
+	TestVolumeMutableParametersFile string
+	TestVolumeMutableParameters     map[string]string
 
 	// Callback functions to customize the creation of target and staging
 	// directories. Returns the new paths for mount and staging.
@@ -245,6 +250,8 @@ func (sc *TestContext) Setup() {
 	loadFromFile(sc.Config.TestVolumeParametersFile, &sc.Config.TestVolumeParameters)
 	// Get VolumeSnapshotClass parameters from TestSnapshotParametersFile
 	loadFromFile(sc.Config.TestSnapshotParametersFile, &sc.Config.TestSnapshotParameters)
+	// Get VolumeAttributeClass parameters from TestVolumeMutableParametersFile
+	loadFromFile(sc.Config.TestVolumeMutableParametersFile, &sc.Config.TestVolumeMutableParameters)
 
 	if len(sc.Config.SecretsFile) > 0 {
 		sc.Secrets, err = loadSecrets(sc.Config.SecretsFile)

--- a/pkg/sanity/util.go
+++ b/pkg/sanity/util.go
@@ -18,8 +18,11 @@ package sanity
 
 import (
 	"fmt"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/google/uuid"
+	. "github.com/onsi/gomega"
 )
 
 // IDGenerator generates valid and invalid Volume and Node IDs to be used in
@@ -63,4 +66,14 @@ func (d DefaultIDGenerator) GenerateUniqueValidNodeID() string {
 
 func (d DefaultIDGenerator) GenerateInvalidNodeID() string {
 	return "fake-node-id"
+}
+
+// ExpectErrorCode confirms that the correct error code was returned
+func ExpectErrorCode(response any, err error, code codes.Code) {
+	Expect(err).To(HaveOccurred())
+	Expect(response).To(BeNil())
+
+	serverError, ok := status.FromError(err)
+	Expect(ok).To(BeTrue())
+	Expect(serverError.Code()).To(Equal(code), "unexpected error: %s", serverError.Message())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
Adds sanity tests for the [ControllerModifyVolume](https://github.com/container-storage-interface/spec/blob/master/spec.md#controllermodifyvolume) RPC such that VolumeAttributesClass ModifyVolume enhancement KEP-3751 can be promoted to Beta

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

N/A

**Special notes for your reviewer**:

Squashed the commits, but previously we also had:
- Bump csi-driver-host-path
- Refactor sanity with ExpectErrorCode helper
- Fix uncleaned tempfile

Active Questions: 
1. ~Should we enforce empty MutableParameters list as InvalidArgument Err? KEP says don't enforce because field OPTIONAL, csi-spec has no mention, [k/k type](https://github.com/kubernetes/kubernetes/blob/c3689b9f8b8c1a1ac2bbc4e3b3cda28d83849ec2/pkg/apis/storage/types.go#L701) says required, hostpath-driver does enforce with InvalidArgument on empty.~ Do not enforce 
2. Should we skip tests if no testvolumemutableparameters yaml file passed in?
3. ~How to enforce no conflicts between SC and VAC if both are opaque? Loop through parameter lists for duplicated keys? Or leave out test for now.~ Leave out for now, made issue #549.  

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add csi-sanity tests for ControllerModifyVolume RPC
```
