### PR TITLE
Cherry-pick #553: Add Protobuf Matcher utility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.13.1
 	github.com/onsi/gomega v1.30.0
 	google.golang.org/grpc v1.65.0
+	google.golang.org/protobuf v1.34.1
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/klog/v2 v2.130.1
 )
@@ -24,6 +25,5 @@ require (
 	golang.org/x/text v0.15.0 // indirect
 	golang.org/x/tools v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240528184218-531527333157 // indirect
-	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/utils/protobuf_matcher.go
+++ b/utils/protobuf_matcher.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"github.com/golang/mock/gomock"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+)
+
+// Protobuf returns a Matcher that relies upon proto.Equal to compare Protobuf messages
+// Example usage with mocked request:
+//
+// example.EXPECT().ExampleRequest(Protobuf(requestMsg)).Return(responseMsg, nil).AnyTimes()
+func Protobuf(msg proto.Message) gomock.Matcher {
+	return &ProtobufMatcher{msg}
+}
+
+type ProtobufMatcher struct {
+	msg proto.Message
+}
+
+var _ gomock.Matcher = &ProtobufMatcher{}
+
+func (p *ProtobufMatcher) Matches(x interface{}) bool {
+	otherMsg, ok := x.(proto.Message)
+	if !ok {
+		return false
+	}
+	return proto.Equal(p.msg, otherMsg)
+}
+
+func (p *ProtobufMatcher) String() string {
+	return prototext.Format(p.msg)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind feature

**What this PR does / why we need it**:

Cherry-pick of #553 because cherrypicker bot not working. 

gomock is not able to match newly generated Protobuf messages from csi-test, because their private fields differ. Implement a custom message matcher for projects that need to mock gRPCs can use.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
action required: If you are upgrading CSI spec to v1.10.0 and rely on mocking gRPC calls in your tests, you may need to use the csi-test utils package's Protobuf Matcher: `example.EXPECT().ExampleRequest(Protobuf(requestMsg)).Return(responseMsg, nil).AnyTimes()`
```
