### PR TITLE
Added the SNAPSHOT_METADATA_SERVICE capability to the identity service sanity test

### DIFF
--- a/pkg/sanity/identity.go
+++ b/pkg/sanity/identity.go
@@ -59,6 +59,7 @@ var _ = DescribeSanity("Identity Service", func(sc *TestContext) {
 						case csi.PluginCapability_Service_CONTROLLER_SERVICE:
 						case csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS:
 						case csi.PluginCapability_Service_GROUP_CONTROLLER_SERVICE:
+						case csi.PluginCapability_Service_SNAPSHOT_METADATA_SERVICE:
 						default:
 							Fail(fmt.Sprintf("Unknown service: %v\n", cap.GetService().GetType()))
 						}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
The sanity test will fail to validate a CSI driver if its identity service `GetPluginCapabilities` operation returns the `csi.PluginCapability_Service_SNAPSHOT_METADATA_SERVICE` capability.
This is a new capability introduced with CSI v1.10.0 so does not impact current drivers.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-csi/csi-test/issues/558

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
