### PR TITLE
fix dereferencing null secrets

### DIFF
--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -222,7 +222,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				VolumeCapabilities: []*csi.VolumeCapability{
 					TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 				},
-				Secrets:    sc.Secrets.CreateVolumeSecret,
+				Secrets:    sc.GetCreateVolumeSecret(),
 				Parameters: sc.Config.TestVolumeParameters,
 			}
 
@@ -240,7 +240,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 
 			delReq := &csi.DeleteVolumeRequest{
 				VolumeId: vol.GetVolume().GetVolumeId(),
-				Secrets:  sc.Secrets.DeleteVolumeSecret,
+				Secrets:  sc.GetDeleteVolumeSecret(),
 			}
 
 			_, err = r.DeleteVolume(context.Background(), delReq)
@@ -296,7 +296,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 						VolumeCapabilities: []*csi.VolumeCapability{
 							TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 						},
-						Secrets:    sc.Secrets.CreateVolumeSecret,
+						Secrets:    sc.GetCreateVolumeSecret(),
 						Parameters: sc.Config.TestVolumeParameters,
 					}
 
@@ -325,7 +325,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				Expect(existing_vols[vol.Volume.VolumeId]).To(BeTrue())
 				delReq := &csi.DeleteVolumeRequest{
 					VolumeId: vol.Volume.VolumeId,
-					Secrets:  sc.Secrets.DeleteVolumeSecret,
+					Secrets:  sc.GetDeleteVolumeSecret(),
 				}
 
 				_, err := r.DeleteVolume(context.Background(), delReq)
@@ -340,7 +340,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				VolumeCapabilities: []*csi.VolumeCapability{
 					TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 				},
-				Secrets:    sc.Secrets.CreateVolumeSecret,
+				Secrets:    sc.GetCreateVolumeSecret(),
 				Parameters: sc.Config.TestVolumeParameters,
 			}
 			vol := r.MustCreateVolume(context.Background(), req)
@@ -374,7 +374,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 			rsp, err := r.CreateVolume(
 				context.Background(),
 				&csi.CreateVolumeRequest{
-					Secrets:    sc.Secrets.CreateVolumeSecret,
+					Secrets:    sc.GetCreateVolumeSecret(),
 					Parameters: sc.Config.TestVolumeParameters,
 				},
 			)
@@ -387,7 +387,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				context.Background(),
 				&csi.CreateVolumeRequest{
 					Name:       name,
-					Secrets:    sc.Secrets.CreateVolumeSecret,
+					Secrets:    sc.GetCreateVolumeSecret(),
 					Parameters: sc.Config.TestVolumeParameters,
 				},
 			)
@@ -410,7 +410,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 					CapacityRange: &csi.CapacityRange{
 						RequiredBytes: TestVolumeSize(sc),
 					},
-					Secrets:    sc.Secrets.CreateVolumeSecret,
+					Secrets:    sc.GetCreateVolumeSecret(),
 					Parameters: sc.Config.TestVolumeParameters,
 				},
 			)
@@ -431,7 +431,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 					CapacityRange: &csi.CapacityRange{
 						RequiredBytes: TestVolumeSize(sc),
 					},
-					Secrets:    sc.Secrets.CreateVolumeSecret,
+					Secrets:    sc.GetCreateVolumeSecret(),
 					Parameters: sc.Config.TestVolumeParameters,
 				},
 			)
@@ -462,7 +462,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 					CapacityRange: &csi.CapacityRange{
 						RequiredBytes: size,
 					},
-					Secrets:    sc.Secrets.CreateVolumeSecret,
+					Secrets:    sc.GetCreateVolumeSecret(),
 					Parameters: sc.Config.TestVolumeParameters,
 				},
 			)
@@ -479,7 +479,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 					CapacityRange: &csi.CapacityRange{
 						RequiredBytes: size,
 					},
-					Secrets:    sc.Secrets.CreateVolumeSecret,
+					Secrets:    sc.GetCreateVolumeSecret(),
 					Parameters: sc.Config.TestVolumeParameters,
 				},
 			)
@@ -504,7 +504,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 						RequiredBytes: size1,
 						LimitBytes:    size1,
 					},
-					Secrets:    sc.Secrets.CreateVolumeSecret,
+					Secrets:    sc.GetCreateVolumeSecret(),
 					Parameters: sc.Config.TestVolumeParameters,
 				},
 			)
@@ -521,7 +521,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 						RequiredBytes: size2,
 						LimitBytes:    size2,
 					},
-					Secrets:    sc.Secrets.CreateVolumeSecret,
+					Secrets:    sc.GetCreateVolumeSecret(),
 					Parameters: sc.Config.TestVolumeParameters,
 				},
 			)
@@ -543,7 +543,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 					CapacityRange: &csi.CapacityRange{
 						RequiredBytes: size,
 					},
-					Secrets:    sc.Secrets.CreateVolumeSecret,
+					Secrets:    sc.GetCreateVolumeSecret(),
 					Parameters: sc.Config.TestVolumeParameters,
 				},
 			)
@@ -688,7 +688,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 			rsp, err := r.DeleteVolume(
 				context.Background(),
 				&csi.DeleteVolumeRequest{
-					Secrets: sc.Secrets.DeleteVolumeSecret,
+					Secrets: sc.GetDeleteVolumeSecret(),
 				},
 			)
 			ExpectErrorCode(rsp, err, codes.InvalidArgument)
@@ -700,7 +700,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				context.Background(),
 				&csi.DeleteVolumeRequest{
 					VolumeId: sc.Config.IDGen.GenerateInvalidVolumeID(),
-					Secrets:  sc.Secrets.DeleteVolumeSecret,
+					Secrets:  sc.GetDeleteVolumeSecret(),
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -722,7 +722,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 					CapacityRange: &csi.CapacityRange{
 						RequiredBytes: TestVolumeSize(sc),
 					},
-					Secrets:    sc.Secrets.CreateVolumeSecret,
+					Secrets:    sc.GetCreateVolumeSecret(),
 					Parameters: sc.Config.TestVolumeParameters,
 				},
 			)
@@ -734,7 +734,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				context.Background(),
 				&csi.DeleteVolumeRequest{
 					VolumeId: vol.GetVolume().GetVolumeId(),
-					Secrets:  sc.Secrets.DeleteVolumeSecret,
+					Secrets:  sc.GetDeleteVolumeSecret(),
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -747,7 +747,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 			rsp, err := r.ValidateVolumeCapabilities(
 				context.Background(),
 				&csi.ValidateVolumeCapabilitiesRequest{
-					Secrets: sc.Secrets.ControllerValidateVolumeCapabilitiesSecret,
+					Secrets: sc.GetControllerValidateVolumeCapabilitiesSecret(),
 				})
 			ExpectErrorCode(rsp, err, codes.InvalidArgument)
 		})
@@ -768,7 +768,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 					CapacityRange: &csi.CapacityRange{
 						RequiredBytes: TestVolumeSize(sc),
 					},
-					Secrets:    sc.Secrets.CreateVolumeSecret,
+					Secrets:    sc.GetCreateVolumeSecret(),
 					Parameters: sc.Config.TestVolumeParameters,
 				},
 			)
@@ -778,7 +778,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				&csi.ValidateVolumeCapabilitiesRequest{
 					VolumeId:           vol.GetVolume().GetVolumeId(),
 					VolumeCapabilities: nil,
-					Secrets:            sc.Secrets.ControllerValidateVolumeCapabilitiesSecret,
+					Secrets:            sc.GetControllerValidateVolumeCapabilitiesSecret(),
 				})
 			ExpectErrorCode(rsp, err, codes.InvalidArgument)
 		})
@@ -799,7 +799,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 					CapacityRange: &csi.CapacityRange{
 						RequiredBytes: TestVolumeSize(sc),
 					},
-					Secrets:    sc.Secrets.CreateVolumeSecret,
+					Secrets:    sc.GetCreateVolumeSecret(),
 					Parameters: sc.Config.TestVolumeParameters,
 				},
 			)
@@ -813,7 +813,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 					VolumeCapabilities: []*csi.VolumeCapability{
 						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					},
-					Secrets: sc.Secrets.ControllerValidateVolumeCapabilitiesSecret,
+					Secrets: sc.GetControllerValidateVolumeCapabilitiesSecret(),
 				})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(valivolcap).NotTo(BeNil())
@@ -834,7 +834,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 					VolumeCapabilities: []*csi.VolumeCapability{
 						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					},
-					Secrets: sc.Secrets.ControllerValidateVolumeCapabilitiesSecret,
+					Secrets: sc.GetControllerValidateVolumeCapabilitiesSecret(),
 				},
 			)
 			ExpectErrorCode(rsp, err, codes.NotFound)
@@ -853,7 +853,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 			rsp, err := r.ControllerPublishVolume(
 				context.Background(),
 				&csi.ControllerPublishVolumeRequest{
-					Secrets: sc.Secrets.ControllerPublishVolumeSecret,
+					Secrets: sc.GetControllerPublishVolumeSecret(),
 				},
 			)
 			ExpectErrorCode(rsp, err, codes.InvalidArgument)
@@ -865,7 +865,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				context.Background(),
 				&csi.ControllerPublishVolumeRequest{
 					VolumeId: sc.Config.IDGen.GenerateUniqueValidVolumeID(),
-					Secrets:  sc.Secrets.ControllerPublishVolumeSecret,
+					Secrets:  sc.GetControllerPublishVolumeSecret(),
 				},
 			)
 			ExpectErrorCode(rsp, err, codes.InvalidArgument)
@@ -878,7 +878,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				&csi.ControllerPublishVolumeRequest{
 					VolumeId: sc.Config.IDGen.GenerateUniqueValidVolumeID(),
 					NodeId:   sc.Config.IDGen.GenerateUniqueValidNodeID(),
-					Secrets:  sc.Secrets.ControllerPublishVolumeSecret,
+					Secrets:  sc.GetControllerPublishVolumeSecret(),
 				},
 			)
 			ExpectErrorCode(rsp, err, codes.InvalidArgument)
@@ -935,7 +935,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 					NodeId:           sc.Config.IDGen.GenerateUniqueValidNodeID(),
 					VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					Readonly:         false,
-					Secrets:          sc.Secrets.ControllerPublishVolumeSecret,
+					Secrets:          sc.GetControllerPublishVolumeSecret(),
 				},
 			)
 			ExpectErrorCode(conpubvol, err, codes.NotFound)
@@ -954,7 +954,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 					VolumeCapabilities: []*csi.VolumeCapability{
 						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					},
-					Secrets:    sc.Secrets.CreateVolumeSecret,
+					Secrets:    sc.GetCreateVolumeSecret(),
 					Parameters: sc.Config.TestVolumeParameters,
 				},
 			)
@@ -969,7 +969,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 					NodeId:           sc.Config.IDGen.GenerateUniqueValidNodeID(),
 					VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					Readonly:         false,
-					Secrets:          sc.Secrets.ControllerPublishVolumeSecret,
+					Secrets:          sc.GetControllerPublishVolumeSecret(),
 				},
 			)
 			Expect(err).To(HaveOccurred())
@@ -996,7 +996,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 					VolumeCapabilities: []*csi.VolumeCapability{
 						TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					},
-					Secrets:    sc.Secrets.CreateVolumeSecret,
+					Secrets:    sc.GetCreateVolumeSecret(),
 					Parameters: sc.Config.TestVolumeParameters,
 				},
 			)
@@ -1017,7 +1017,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 				NodeId:           nid.GetNodeId(),
 				VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 				Readonly:         false,
-				Secrets:          sc.Secrets.ControllerPublishVolumeSecret,
+				Secrets:          sc.GetControllerPublishVolumeSecret(),
 			}
 
 			conpubvol := r.MustControllerPublishVolume(context.Background(), pubReq)
@@ -1058,7 +1058,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 			rsp, err := r.ControllerUnpublishVolume(
 				context.Background(),
 				&csi.ControllerUnpublishVolumeRequest{
-					Secrets: sc.Secrets.ControllerUnpublishVolumeSecret,
+					Secrets: sc.GetControllerUnpublishVolumeSecret(),
 				},
 			)
 			ExpectErrorCode(rsp, err, codes.InvalidArgument)
@@ -1491,7 +1491,7 @@ var _ = DescribeSanity("ExpandVolume [Controller Server]", func(sc *TestContext)
 	It("should fail if no capacity range is given", func() {
 		expReq := &csi.ControllerExpandVolumeRequest{
 			VolumeId: "",
-			Secrets:  sc.Secrets.ControllerExpandVolumeSecret,
+			Secrets:  sc.GetControllerExpandVolumeSecret(),
 		}
 		rsp, err := r.ControllerExpandVolume(context.Background(), expReq)
 		ExpectErrorCode(rsp, err, codes.InvalidArgument)
@@ -1509,7 +1509,7 @@ var _ = DescribeSanity("ExpandVolume [Controller Server]", func(sc *TestContext)
 				TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 			},
 			Parameters: sc.Config.TestVolumeParameters,
-			Secrets:    sc.Secrets.CreateVolumeSecret,
+			Secrets:    sc.GetCreateVolumeSecret(),
 			CapacityRange: &csi.CapacityRange{
 				RequiredBytes: TestVolumeSize(sc),
 			},
@@ -1569,7 +1569,7 @@ var _ = DescribeSanity("ModifyVolume [Controller Server]", func(sc *TestContext)
 			MutableParameters: map[string]string{
 				"XXX_FakeKey": "XXX_FakeValue",
 			},
-			Secrets: sc.Secrets.ControllerModifyVolumeSecret,
+			Secrets: sc.GetControllerModifyVolumeSecret(),
 		}
 		rsp, err := r.ControllerModifyVolume(context.Background(), modifyReq)
 		ExpectErrorCode(rsp, err, codes.InvalidArgument)
@@ -1623,7 +1623,7 @@ var _ = DescribeSanity("ModifyVolume [Controller Server]", func(sc *TestContext)
 			MutableParameters: map[string]string{
 				"XXX_FakeKey": "XXX_FakeValue",
 			},
-			Secrets: sc.Secrets.ControllerModifyVolumeSecret,
+			Secrets: sc.GetControllerModifyVolumeSecret(),
 		}
 		rsp, err := r.ControllerModifyVolume(context.Background(), modifyReq)
 		ExpectErrorCode(rsp, err, codes.InvalidArgument)
@@ -1697,7 +1697,7 @@ func MakeControllerPublishVolumeReq(sc *TestContext, volID, nodeID string) *csi.
 		NodeId:           nodeID,
 		VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 		Readonly:         false,
-		Secrets:          sc.Secrets.ControllerPublishVolumeSecret,
+		Secrets:          sc.GetControllerPublishVolumeSecret(),
 	}
 }
 
@@ -1706,7 +1706,7 @@ func MakeControllerUnpublishVolumeReq(sc *TestContext, volID, nodeID string) *cs
 	return &csi.ControllerUnpublishVolumeRequest{
 		VolumeId: volID,
 		NodeId:   nodeID,
-		Secrets:  sc.Secrets.ControllerUnpublishVolumeSecret,
+		Secrets:  sc.GetControllerUnpublishVolumeSecret(),
 	}
 }
 
@@ -1717,7 +1717,7 @@ func MakeExpandVolumeReq(sc *TestContext, volID string) *csi.ControllerExpandVol
 		CapacityRange: &csi.CapacityRange{
 			RequiredBytes: TestVolumeExpandSize(sc),
 		},
-		Secrets:          sc.Secrets.ControllerExpandVolumeSecret,
+		Secrets:          sc.GetControllerExpandVolumeSecret(),
 		VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 	}
 }
@@ -1727,7 +1727,7 @@ func MakeModifyVolumeReq(sc *TestContext, volID string) *csi.ControllerModifyVol
 	return &csi.ControllerModifyVolumeRequest{
 		VolumeId:          volID,
 		MutableParameters: sc.Config.TestVolumeMutableParameters,
-		Secrets:           sc.Secrets.ControllerModifyVolumeSecret,
+		Secrets:           sc.GetControllerModifyVolumeSecret(),
 	}
 }
 
@@ -1762,7 +1762,7 @@ func VolumeLifecycle(r *Resources, sc *TestContext, count int) {
 			VolumeCapabilities: []*csi.VolumeCapability{
 				TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 			},
-			Secrets:                   sc.Secrets.CreateVolumeSecret,
+			Secrets:                   sc.GetCreateVolumeSecret(),
 			Parameters:                sc.Config.TestVolumeParameters,
 			AccessibilityRequirements: accReqs,
 		},
@@ -1779,7 +1779,7 @@ func VolumeLifecycle(r *Resources, sc *TestContext, count int) {
 				VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 				VolumeContext:    vol.GetVolume().GetVolumeContext(),
 				Readonly:         false,
-				Secrets:          sc.Secrets.ControllerPublishVolumeSecret,
+				Secrets:          sc.GetControllerPublishVolumeSecret(),
 			},
 		)
 	}

--- a/pkg/sanity/groupcontroller.go
+++ b/pkg/sanity/groupcontroller.go
@@ -157,7 +157,7 @@ var _ = DescribeSanity("GroupController Service [GroupController VolumeGroupSnap
 			rsp, err := r.CreateVolumeGroupSnapshot(
 				context.Background(),
 				&csi.CreateVolumeGroupSnapshotRequest{
-					Secrets: sc.Secrets.CreateSnapshotSecret,
+					Secrets: sc.GetCreateSnapshotSecret(),
 				},
 			)
 			ExpectErrorCode(rsp, err, codes.InvalidArgument)
@@ -169,7 +169,7 @@ var _ = DescribeSanity("GroupController Service [GroupController VolumeGroupSnap
 			rsp, err := r.GetVolumeGroupSnapshot(
 				context.Background(),
 				&csi.GetVolumeGroupSnapshotRequest{
-					Secrets: sc.Secrets.ListSnapshotsSecret,
+					Secrets: sc.GetListSnapshotsSecret(),
 				},
 			)
 			ExpectErrorCode(rsp, err, codes.InvalidArgument)
@@ -180,7 +180,7 @@ var _ = DescribeSanity("GroupController Service [GroupController VolumeGroupSnap
 				context.Background(),
 				&csi.GetVolumeGroupSnapshotRequest{
 					GroupSnapshotId: sc.Config.IDGen.GenerateInvalidVolumeID(),
-					Secrets:         sc.Secrets.ListSnapshotsSecret,
+					Secrets:         sc.GetListSnapshotsSecret(),
 				},
 			)
 			ExpectErrorCode(rsp, err, codes.NotFound)
@@ -192,7 +192,7 @@ var _ = DescribeSanity("GroupController Service [GroupController VolumeGroupSnap
 			rsp, err := r.DeleteVolumeGroupSnapshot(
 				context.Background(),
 				&csi.DeleteVolumeGroupSnapshotRequest{
-					Secrets: sc.Secrets.DeleteSnapshotSecret,
+					Secrets: sc.GetDeleteSnapshotSecret(),
 				},
 			)
 			ExpectErrorCode(rsp, err, codes.InvalidArgument)
@@ -203,7 +203,7 @@ var _ = DescribeSanity("GroupController Service [GroupController VolumeGroupSnap
 				context.Background(),
 				&csi.DeleteVolumeGroupSnapshotRequest{
 					GroupSnapshotId: sc.Config.IDGen.GenerateInvalidVolumeID(),
-					Secrets:         sc.Secrets.DeleteSnapshotSecret,
+					Secrets:         sc.GetDeleteSnapshotSecret(),
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -96,7 +96,7 @@ func runControllerTest(sc *TestContext, r *Resources, controllerPublishSupported
 			CapacityRange: &csi.CapacityRange{
 				RequiredBytes: TestVolumeSize(sc),
 			},
-			Secrets:                   sc.Secrets.CreateVolumeSecret,
+			Secrets:                   sc.GetCreateVolumeSecret(),
 			Parameters:                sc.Config.TestVolumeParameters,
 			AccessibilityRequirements: accReqs,
 		},
@@ -114,7 +114,7 @@ func runControllerTest(sc *TestContext, r *Resources, controllerPublishSupported
 				VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 				VolumeContext:    vol.GetVolume().GetVolumeContext(),
 				Readonly:         false,
-				Secrets:          sc.Secrets.ControllerPublishVolumeSecret,
+				Secrets:          sc.GetControllerPublishVolumeSecret(),
 			},
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -132,7 +132,7 @@ func runControllerTest(sc *TestContext, r *Resources, controllerPublishSupported
 					StagingTargetPath: sc.StagingPath,
 					VolumeContext:     vol.GetVolume().GetVolumeContext(),
 					PublishContext:    conpubvol.GetPublishContext(),
-					Secrets:           sc.Secrets.NodeStageVolumeSecret,
+					Secrets:           sc.GetNodeStageVolumeSecret(),
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -155,7 +155,7 @@ func runControllerTest(sc *TestContext, r *Resources, controllerPublishSupported
 				VolumeCapability:  TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 				VolumeContext:     vol.GetVolume().GetVolumeContext(),
 				PublishContext:    conpubvol.GetPublishContext(),
-				Secrets:           sc.Secrets.NodePublishVolumeSecret,
+				Secrets:           sc.GetNodePublishVolumeSecret(),
 			},
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -201,7 +201,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 				CapacityRange: &csi.CapacityRange{
 					RequiredBytes: TestVolumeSize(sc),
 				},
-				Secrets:    sc.Secrets.CreateVolumeSecret,
+				Secrets:    sc.GetCreateVolumeSecret(),
 				Parameters: sc.Config.TestVolumeParameters,
 			},
 		)
@@ -220,7 +220,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 					VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 					VolumeContext:    vol.GetVolume().GetVolumeContext(),
 					Readonly:         false,
-					Secrets:          sc.Secrets.ControllerPublishVolumeSecret,
+					Secrets:          sc.GetControllerPublishVolumeSecret(),
 				},
 			)
 		}
@@ -236,7 +236,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 				VolumeCapability:  TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 				StagingTargetPath: sc.StagingPath,
 				VolumeContext:     vol.GetVolume().GetVolumeContext(),
-				Secrets:           sc.Secrets.NodeStageVolumeSecret,
+				Secrets:           sc.GetNodeStageVolumeSecret(),
 			}
 			if conpubvol != nil {
 				nodeStageRequest.PublishContext = conpubvol.GetPublishContext()
@@ -264,7 +264,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 			StagingTargetPath: stagingPath,
 			VolumeCapability:  TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 			VolumeContext:     vol.GetVolume().GetVolumeContext(),
-			Secrets:           sc.Secrets.NodePublishVolumeSecret,
+			Secrets:           sc.GetNodePublishVolumeSecret(),
 		}
 
 		if conpubvol != nil {
@@ -378,7 +378,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 			rsp, err := r.NodePublishVolume(
 				context.Background(),
 				&csi.NodePublishVolumeRequest{
-					Secrets: sc.Secrets.NodePublishVolumeSecret,
+					Secrets: sc.GetNodePublishVolumeSecret(),
 				},
 			)
 			ExpectErrorCode(rsp, err, codes.InvalidArgument)
@@ -389,7 +389,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 				context.Background(),
 				&csi.NodePublishVolumeRequest{
 					VolumeId: sc.Config.IDGen.GenerateUniqueValidVolumeID(),
-					Secrets:  sc.Secrets.NodePublishVolumeSecret,
+					Secrets:  sc.GetNodePublishVolumeSecret(),
 				},
 			)
 			ExpectErrorCode(rsp, err, codes.InvalidArgument)
@@ -402,7 +402,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 					VolumeId:         sc.Config.IDGen.GenerateUniqueValidVolumeID(),
 					VolumeCapability: nil,
 					TargetPath:       sc.TargetPath + "/target",
-					Secrets:          sc.Secrets.NodePublishVolumeSecret,
+					Secrets:          sc.GetNodePublishVolumeSecret(),
 				},
 			)
 			ExpectErrorCode(rsp, err, codes.InvalidArgument)
@@ -509,7 +509,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 					PublishContext: map[string]string{
 						"device": device,
 					},
-					Secrets: sc.Secrets.NodeStageVolumeSecret,
+					Secrets: sc.GetNodeStageVolumeSecret(),
 				},
 			)
 			ExpectErrorCode(rsp, err, codes.InvalidArgument)
@@ -524,7 +524,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 					PublishContext: map[string]string{
 						"device": device,
 					},
-					Secrets: sc.Secrets.NodeStageVolumeSecret,
+					Secrets: sc.GetNodeStageVolumeSecret(),
 				},
 			)
 			ExpectErrorCode(rsp, err, codes.InvalidArgument)
@@ -550,7 +550,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 							},
 						},
 					},
-					Secrets:    sc.Secrets.CreateVolumeSecret,
+					Secrets:    sc.GetCreateVolumeSecret(),
 					Parameters: sc.Config.TestVolumeParameters,
 				},
 			)
@@ -563,7 +563,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 					PublishContext: map[string]string{
 						"device": device,
 					},
-					Secrets: sc.Secrets.NodeStageVolumeSecret,
+					Secrets: sc.GetNodeStageVolumeSecret(),
 				},
 			)
 			ExpectErrorCode(rsp, err, codes.InvalidArgument)
@@ -729,7 +729,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 					CapacityRange: &csi.CapacityRange{
 						RequiredBytes: TestVolumeExpandSize(sc),
 					},
-					Secrets: sc.Secrets.ControllerExpandVolumeSecret,
+					Secrets: sc.GetControllerExpandVolumeSecret(),
 				}
 				rsp, err := r.ControllerExpandVolume(context.Background(), expReq)
 				Expect(err).NotTo(HaveOccurred())

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -218,6 +218,142 @@ func NewTestContext(config *TestConfig) *TestContext {
 	}
 }
 
+// GetCreateVolumeSecret retrieves the secret credentials required for creating
+// a volume. This function returns a map containing the key-value pairs of the
+// secret if available in the TestContext's CSISecrets structure. If no secret
+// is defined for CreateVolumeSecret, it returns nil.
+func (tc *TestContext) GetCreateVolumeSecret() map[string]string {
+	if tc.Secrets == nil {
+		return nil
+	}
+	return tc.Secrets.CreateVolumeSecret
+}
+
+// GetDeleteVolumeSecret retrieves the secret credentials required for deleting
+// a volume. This function returns a map containing the key-value pairs of the
+// secret if available in the TestContext's CSISecrets structure. If no secret
+// is defined for DeleteVolumeSecret, it returns nil.
+func (tc *TestContext) GetDeleteVolumeSecret() map[string]string {
+	if tc.Secrets == nil {
+		return nil
+	}
+	return tc.Secrets.DeleteVolumeSecret
+}
+
+// GetControllerPublishVolumeSecret retrieves the secret credentials required
+// for publishing a volume by the controller. This function returns a map
+// containing the key-value pairs of the secret if available in the TestContext's
+// CSISecrets structure. If no secret is defined for ControllerPublishVolumeSecret,
+// it returns nil.
+func (tc *TestContext) GetControllerPublishVolumeSecret() map[string]string {
+	if tc.Secrets == nil {
+		return nil
+	}
+	return tc.Secrets.ControllerPublishVolumeSecret
+}
+
+// GetControllerUnpublishVolumeSecret retrieves the secret credentials required
+// for unpublishing a volume by the controller. This function returns a map
+// containing the key-value pairs of the secret if available in the TestContext's
+// CSISecrets structure. If no secret is defined for ControllerUnpublishVolumeSecret,
+// it returns nil.
+func (tc *TestContext) GetControllerUnpublishVolumeSecret() map[string]string {
+	if tc.Secrets == nil {
+		return nil
+	}
+	return tc.Secrets.ControllerUnpublishVolumeSecret
+}
+
+// GetControllerValidateVolumeCapabilitiesSecret retrieves the secret credentials
+// required for validating volume capabilities. This function returns a map
+// containing the key-value pairs of the secret if available in the TestContext's
+// CSISecrets structure. If no secret is defined for ControllerValidateVolumeCapabilitiesSecret,
+// it returns nil.
+func (tc *TestContext) GetControllerValidateVolumeCapabilitiesSecret() map[string]string {
+	if tc.Secrets == nil {
+		return nil
+	}
+	return tc.Secrets.ControllerValidateVolumeCapabilitiesSecret
+}
+
+// GetNodeStageVolumeSecret retrieves the secret credentials required for staging
+// a volume on the node. This function returns a map containing the key-value
+// pairs of the secret if available in the TestContext's CSISecrets structure.
+// If no secret is defined for NodeStageVolumeSecret, it returns nil.
+func (tc *TestContext) GetNodeStageVolumeSecret() map[string]string {
+	if tc.Secrets == nil {
+		return nil
+	}
+	return tc.Secrets.NodeStageVolumeSecret
+}
+
+// GetNodePublishVolumeSecret retrieves the secret credentials required for
+// publishing a volume on the node. This function returns a map containing
+// the key-value pairs of the secret if available in the TestContext's
+// CSISecrets structure. If no secret is defined for NodePublishVolumeSecret,
+// it returns nil.
+func (tc *TestContext) GetNodePublishVolumeSecret() map[string]string {
+	if tc.Secrets == nil {
+		return nil
+	}
+	return tc.Secrets.NodePublishVolumeSecret
+}
+
+// GetCreateSnapshotSecret retrieves the secret credentials required for creating
+// a snapshot. This function returns a map containing the key-value pairs of
+// the secret if available in the TestContext's CSISecrets structure. If no secret
+// is defined for CreateSnapshotSecret, it returns nil.
+func (tc *TestContext) GetCreateSnapshotSecret() map[string]string {
+	if tc.Secrets == nil {
+		return nil
+	}
+	return tc.Secrets.CreateSnapshotSecret
+}
+
+// GetDeleteSnapshotSecret retrieves the secret credentials required for deleting
+// a snapshot. This function returns a map containing the key-value pairs of the
+// secret if available in the TestContext's CSISecrets structure. If no secret is
+// defined for DeleteSnapshotSecret, it returns nil.
+func (tc *TestContext) GetDeleteSnapshotSecret() map[string]string {
+	if tc.Secrets == nil {
+		return nil
+	}
+	return tc.Secrets.DeleteSnapshotSecret
+}
+
+// GetControllerExpandVolumeSecret retrieves the secret credentials required
+// for expanding a volume. This function returns a map containing the key-value
+// pairs of the secret if available in the TestContext's CSISecrets structure.
+// If no secret is defined for ControllerExpandVolumeSecret, it returns nil.
+func (tc *TestContext) GetControllerExpandVolumeSecret() map[string]string {
+	if tc.Secrets == nil {
+		return nil
+	}
+	return tc.Secrets.ControllerExpandVolumeSecret
+}
+
+// GetControllerModifyVolumeSecret retrieves the secret credentials required
+// for modifying a volume. This function returns a map containing the key-value
+// pairs of the secret if available in the TestContext's CSISecrets structure.
+// If no secret is defined for ControllerModifyVolumeSecret, it returns nil.
+func (tc *TestContext) GetControllerModifyVolumeSecret() map[string]string {
+	if tc.Secrets == nil {
+		return nil
+	}
+	return tc.Secrets.ControllerModifyVolumeSecret
+}
+
+// GetListSnapshotsSecret retrieves the secret credentials required for listing
+// snapshots. This function returns a map containing the key-value pairs of the
+// secret if available in the TestContext's CSISecrets structure. If no secret is
+// defined for ListSnapshotsSecret, it returns nil.
+func (tc *TestContext) GetListSnapshotsSecret() map[string]string {
+	if tc.Secrets == nil {
+		return nil
+	}
+	return tc.Secrets.ListSnapshotsSecret
+}
+
 // Test will test the CSI driver at the specified address by
 // setting up a Ginkgo suite and running it.
 func Test(t GinkgoTestingT, config TestConfig) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #562

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a bug where if tests were run with no secrets, they would panic
```
