### PR TITLE
use unique name for volume

### DIFF
--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -1559,7 +1559,7 @@ var _ = DescribeSanity("ModifyVolume [Controller Server]", func(sc *TestContext)
 
 		By("creating a new volume")
 
-		volReq := MakeCreateVolumeReq(sc, UniqueString("sanity-modify-volume"))
+		volReq := MakeCreateVolumeReq(sc, UniqueString("sanity-modify-volume-unsupported"))
 		vol := r.MustCreateVolume(context.Background(), volReq)
 
 		By("failing to modify the volume")
@@ -1595,7 +1595,7 @@ var _ = DescribeSanity("ModifyVolume [Controller Server]", func(sc *TestContext)
 
 		By("creating a new volume with volume attribute class")
 
-		volReq := MakeCreateVolumeReq(sc, UniqueString("sanity-modify-volume"))
+		volReq := MakeCreateVolumeReq(sc, UniqueString("sanity-modify-volume-with-vac"))
 		volReq.MutableParameters = sc.Config.TestVolumeMutableParameters
 		vol := r.MustCreateVolume(context.Background(), volReq)
 
@@ -1612,7 +1612,7 @@ var _ = DescribeSanity("ModifyVolume [Controller Server]", func(sc *TestContext)
 
 		By("creating a new volume with volume attribute class")
 
-		volReq := MakeCreateVolumeReq(sc, UniqueString("sanity-modify-volume"))
+		volReq := MakeCreateVolumeReq(sc, UniqueString("sanity-modify-volume-with-vac-not-supported"))
 		volReq.MutableParameters = sc.Config.TestVolumeMutableParameters
 		vol := r.MustCreateVolume(context.Background(), volReq)
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

The name is used to achieve idempotency. To create multiple volumes, we need different names.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Like #476

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
