### PR TITLE
Always honer topology requirements

### DIFF
--- a/pkg/sanity/tests.go
+++ b/pkg/sanity/tests.go
@@ -43,8 +43,8 @@ func registerTestsInGinkgo(sc *TestContext) {
 	for _, test := range tests {
 		test := test
 		Describe(test.text, func() {
-			BeforeEach(func() {
-				sc.Setup()
+			BeforeEach(func(ctx SpecContext) {
+				sc.Setup(ctx)
 			})
 
 			test.body(sc)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When testing a multi-zone cluster, the provisioned volume may not attachable to the node if AccessibilityRequirements is not provided.

Move `NodeGetInfo` to setup, as this is needed for nearly every cases.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Always honer topology requirements
```
