### PR TITLE
feat: add support for specifying volume topology requirements for CreateVolumeRequest via a configuration file.

### DIFF
--- a/cmd/csi-sanity/main.go
+++ b/cmd/csi-sanity/main.go
@@ -90,6 +90,7 @@ func main() {
 	stringVar(&config.TestVolumeParametersFile, "testvolumeparameters", "YAML file of volume parameters for provisioned volumes")
 	stringVar(&config.TestVolumeMutableParametersFile, "testvolumemutableparameters", "YAML file of mutable parameters for modifying volumes")
 	stringVar(&config.TestSnapshotParametersFile, "testsnapshotparameters", "YAML file of snapshot parameters for provisioned snapshots")
+	stringVar(&config.TestTopologyRequirementsFile, "testtopologyrequirements", "YAML file of topology requirements for provisioned volumes")
 	boolVar(&config.TestNodeVolumeAttachLimit, "testnodevolumeattachlimit", "Test node volume attach limit")
 	flag.Var(flag.Lookup("ginkgo.junit-report").Value, prefix+"junitfile", "JUnit XML output file where test results will be written (deprecated: use ginkgo.junit-report instead)")
 

--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -1504,6 +1504,10 @@ func MakeCreateVolumeReq(sc *TestContext, name string) *csi.CreateVolumeRequest 
 		Parameters: sc.Config.TestVolumeParameters,
 	}
 
+	if sc.Config.TestTopologyRequirements != nil {
+		req.AccessibilityRequirements = sc.Config.TestTopologyRequirements
+	}
+
 	if sc.Secrets != nil {
 		req.Secrets = sc.Secrets.CreateVolumeSecret
 	}

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-csi/csi-test/v5/utils"
 	yaml "gopkg.in/yaml.v2"
 
@@ -105,6 +106,10 @@ type TestConfig struct {
 	// TestVolumeMutableParametersFile for setting ModifyVolumeRequest.MutableParameters.
 	TestVolumeMutableParametersFile string
 	TestVolumeMutableParameters     map[string]string
+
+	// TestTopologyRequirementsFile for setting CreateVolumeRequest.AccessibilityRequirements.
+	TestTopologyRequirementsFile string
+	TestTopologyRequirements     *csi.TopologyRequirement
 
 	// Callback functions to customize the creation of target and staging
 	// directories. Returns the new paths for mount and staging.
@@ -252,6 +257,8 @@ func (sc *TestContext) Setup() {
 	loadFromFile(sc.Config.TestSnapshotParametersFile, &sc.Config.TestSnapshotParameters)
 	// Get VolumeAttributeClass parameters from TestVolumeMutableParametersFile
 	loadFromFile(sc.Config.TestVolumeMutableParametersFile, &sc.Config.TestVolumeMutableParameters)
+	// Get TopologyRequirement parameters from TestTopologyRequirementsFile
+	loadFromFile(sc.Config.TestTopologyRequirementsFile, &sc.Config.TestTopologyRequirements)
 
 	if len(sc.Config.SecretsFile) > 0 {
 		sc.Secrets, err = loadSecrets(sc.Config.SecretsFile)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:

***Added Configurable Topology Requirements to CSI Sanity Tests***
I have added support for injecting TopologyRequirement into CreateVolumeRequest calls in the CSI sanity tests. This allows testing drivers that require specific topology constraints.

**Special notes for your reviewer**:

Usage
To use this feature, create a YAML file with your topology requirements. Example:

```
requisite:
  - segments:
      "topology.kubernetes.io/migration_domain": "1"
preferred:
  - segments:
      "topology.kubernetes.io/migration_domain": "1"
```

Then run csi-sanity with the flag:

`csi-sanity --csi.endpoint=<endpoint> --csi.testtopologyrequirements=path/to/topology.yaml`




**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
