### PR TITLE
fix(sanity): allow custom snapshot IDs

### DIFF
--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -510,7 +510,7 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 			volReq.VolumeContentSource = &csi.VolumeContentSource{
 				Type: &csi.VolumeContentSource_Snapshot{
 					Snapshot: &csi.VolumeContentSource_SnapshotSource{
-						SnapshotId: "non-existing-snapshot-id",
+						SnapshotId: sc.Config.IDGen.GenerateUniqueValidSnapshotID(),
 					},
 				},
 			}
@@ -1220,7 +1220,7 @@ var _ = DescribeSanity("DeleteSnapshot [Controller Server]", func(sc *TestContex
 
 	It("should succeed when an invalid snapshot id is used", func() {
 
-		req := MakeDeleteSnapshotReq(sc, "reallyfakesnapshotid")
+		req := MakeDeleteSnapshotReq(sc, sc.Config.IDGen.GenerateInvalidSnapshotID())
 		_, err := r.DeleteSnapshot(context.Background(), req)
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/pkg/sanity/util.go
+++ b/pkg/sanity/util.go
@@ -37,6 +37,15 @@ type IDGenerator interface {
 	// case this method should output any non-empty ID
 	GenerateInvalidVolumeID() string
 
+	// GenerateUniqueValidSnapshotID must generate a unique Snapshot ID that the CSI
+	// Driver considers in valid form
+	GenerateUniqueValidSnapshotID() string
+
+	// GenerateInvalidSnapshotID must output a Snapshot ID that the CSI Driver MAY
+	// consider invalid. Some drivers may not have requirements on IDs in which
+	// case this method should output any non-empty ID
+	GenerateInvalidSnapshotID() string
+
 	// GenerateUniqueValidNodeID must generate a unique Node ID that the CSI
 	// Driver considers in valid form
 	GenerateUniqueValidNodeID() string
@@ -58,6 +67,14 @@ func (d DefaultIDGenerator) GenerateUniqueValidVolumeID() string {
 
 func (d DefaultIDGenerator) GenerateInvalidVolumeID() string {
 	return "fake-vol-id"
+}
+
+func (d DefaultIDGenerator) GenerateUniqueValidSnapshotID() string {
+	return fmt.Sprintf("fake-snap-id-%s", uuid.New().String()[:10])
+}
+
+func (d DefaultIDGenerator) GenerateInvalidSnapshotID() string {
+	return "fake-snap-id"
 }
 
 func (d DefaultIDGenerator) GenerateUniqueValidNodeID() string {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The sanity tests did not allow use of custom snapshot ids.

The "missing snapshot" ID used in tests would be considered invalid by many providers.

This PR adds new snapshot ID generation methods to the IDGenerator interface, allowing the user to generate custom valid/invalid snapshot IDs.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Add custom Snapshot ID methods to the IDGenerator interface. [action required] If you set a custom ID generator, you will need to implement the new methods. 
```
