### PR TITLE
Allow empty controller capability responses

### DIFF
--- a/pkg/sanity/controller.go
+++ b/pkg/sanity/controller.go
@@ -95,7 +95,6 @@ func isControllerCapabilitySupported(
 		&csi.ControllerGetCapabilitiesRequest{})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(caps).NotTo(BeNil())
-	Expect(caps.GetCapabilities()).NotTo(BeNil())
 
 	for _, cap := range caps.GetCapabilities() {
 		Expect(cap.GetRpc()).NotTo(BeNil())
@@ -130,7 +129,6 @@ var _ = DescribeSanity("Controller Service [Controller Server]", func(sc *TestCo
 			By("checking successful response")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(caps).NotTo(BeNil())
-			Expect(caps.GetCapabilities()).NotTo(BeNil())
 
 			for _, cap := range caps.GetCapabilities() {
 				Expect(cap.GetRpc()).NotTo(BeNil())


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

`ControllerGetCapabilitiesResponse.capabilities` is a repeated protobuf field. In proto3, an unset repeated field and an empty repeated field are encoded the same way, so a valid response with zero controller capabilities may be decoded as a nil slice.

`isControllerCapabilitySupported` rejected that valid response with `Expect(caps.GetCapabilities()).NotTo(BeNil())`, causing sanity tests to fail instead of treating the capability as unsupported.

This PR removes the nil-slice assertions and lets the existing loops handle zero capabilities correctly.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #596

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
