### PR TITLE
Assert SINGLE_NODE_SINGLE_WRITER volume behavior

### DIFF
--- a/hack/_apitest2/api_test.go
+++ b/hack/_apitest2/api_test.go
@@ -31,10 +31,10 @@ func TestMyDriverWithCustomTargetPaths(t *testing.T) {
 	var createTargetDirCalls, createStagingDirCalls,
 		removeTargetDirCalls, removeStagingDirCalls int
 
-	wantCreateTargetCalls := 3
-	wantCreateStagingCalls := 3
-	wantRemoveTargetCalls := 3
-	wantRemoveStagingCalls := 3
+	wantCreateTargetCalls := 4
+	wantCreateStagingCalls := 4
+	wantRemoveTargetCalls := 4
+	wantRemoveStagingCalls := 4
 
 	// tmpPath could be a CO specific directory under which all the target dirs
 	// are created. For k8s, it could be /var/lib/kubelet/pods under which the

--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -169,12 +169,13 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 	var (
 		r *Resources
 
-		providesControllerService    bool
-		controllerPublishSupported   bool
-		nodeStageSupported           bool
-		nodeVolumeStatsSupported     bool
-		nodeExpansionSupported       bool
-		controllerExpansionSupported bool
+		providesControllerService      bool
+		controllerPublishSupported     bool
+		nodeStageSupported             bool
+		nodeVolumeStatsSupported       bool
+		nodeExpansionSupported         bool
+		controllerExpansionSupported   bool
+		singleNodeMultiWriterSupported bool
 	)
 
 	createVolumeWithCapability := func(volumeName string, volCap *csi.VolumeCapability) *csi.CreateVolumeResponse {
@@ -304,6 +305,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 		if providesControllerService {
 			controllerExpansionSupported = isControllerCapabilitySupported(cl, csi.ControllerServiceCapability_RPC_EXPAND_VOLUME)
 		}
+		singleNodeMultiWriterSupported = isNodeCapabilitySupported(n, csi.NodeServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER)
 		r = &Resources{
 			Context:          sc,
 			ControllerClient: cl,
@@ -403,6 +405,53 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 				},
 			)
 			ExpectErrorCode(rsp, err, codes.InvalidArgument)
+		})
+
+		Describe("with single node multi writer capability", func() {
+			BeforeEach(func() {
+				if !singleNodeMultiWriterSupported {
+					Skip("Service does not have single node multi writer capability")
+				}
+			})
+
+			It("should fail when volume with single node single writer access mode is already mounted at a different target path", func() {
+				By("creating a single node single writer volume")
+				name := UniqueString("sanity-node-publish-single-node-single-writer")
+				cap := TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER)
+				vol := createVolumeWithCapability(name, cap)
+
+				By("Getting a node id")
+				nid, err := r.NodeGetInfo(
+					context.Background(),
+					&csi.NodeGetInfoRequest{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(nid).NotTo(BeNil())
+				Expect(nid.GetNodeId()).NotTo(BeEmpty())
+
+				By("Staging and publishing a volume")
+				conpubvol := controllerPublishVolumeWithCapability(name, vol, nid, cap)
+				_ = nodeStageVolumeWithCapability(name, vol, conpubvol, cap)
+				_ = nodePublishVolumeWithCapability(name, vol, conpubvol, cap)
+
+				nodePublishRequest := &csi.NodePublishVolumeRequest{
+					VolumeId:         vol.GetVolume().GetVolumeId(),
+					TargetPath:       sc.TargetPath + "/other_target",
+					VolumeCapability: cap,
+					VolumeContext:    vol.GetVolume().GetVolumeContext(),
+					Secrets:          sc.Secrets.NodePublishVolumeSecret,
+				}
+				if conpubvol != nil {
+					nodePublishRequest.PublishContext = conpubvol.GetPublishContext()
+				}
+				if nodeStageSupported {
+					nodePublishRequest.StagingTargetPath = sc.StagingPath
+				}
+
+				rsp, err := r.NodePublishVolume(
+					context.Background(),
+					nodePublishRequest)
+				ExpectErrorCode(rsp, err, codes.FailedPrecondition)
+			})
 		})
 	})
 

--- a/pkg/sanity/node.go
+++ b/pkg/sanity/node.go
@@ -177,15 +177,13 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 		controllerExpansionSupported bool
 	)
 
-	createVolume := func(volumeName string) *csi.CreateVolumeResponse {
-		By("creating a single node writer volume for expansion")
-		return r.MustCreateVolume(
-			context.Background(),
-			MakeCreateVolumeReq(sc, volumeName),
-		)
+	createVolumeWithCapability := func(volumeName string, volCap *csi.VolumeCapability) *csi.CreateVolumeResponse {
+		req := MakeCreateVolumeReq(sc, volumeName)
+		req.VolumeCapabilities = []*csi.VolumeCapability{volCap}
+		return r.MustCreateVolume(context.Background(), req)
 	}
 
-	controllerPublishVolume := func(volumeName string, vol *csi.CreateVolumeResponse, nid *csi.NodeGetInfoResponse) *csi.ControllerPublishVolumeResponse {
+	controllerPublishVolumeWithCapability := func(volumeName string, vol *csi.CreateVolumeResponse, nid *csi.NodeGetInfoResponse, volCap *csi.VolumeCapability) *csi.ControllerPublishVolumeResponse {
 		var conpubvol *csi.ControllerPublishVolumeResponse
 		if controllerPublishSupported {
 			By("controller publishing volume")
@@ -195,7 +193,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 				&csi.ControllerPublishVolumeRequest{
 					VolumeId:         vol.GetVolume().GetVolumeId(),
 					NodeId:           nid.GetNodeId(),
-					VolumeCapability: TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+					VolumeCapability: volCap,
 					VolumeContext:    vol.GetVolume().GetVolumeContext(),
 					Readonly:         false,
 					Secrets:          sc.Secrets.ControllerPublishVolumeSecret,
@@ -205,13 +203,13 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 		return conpubvol
 	}
 
-	nodeStageVolume := func(volumeName string, vol *csi.CreateVolumeResponse, conpubvol *csi.ControllerPublishVolumeResponse) *csi.NodeStageVolumeResponse {
+	nodeStageVolumeWithCapability := func(volumeName string, vol *csi.CreateVolumeResponse, conpubvol *csi.ControllerPublishVolumeResponse, volCap *csi.VolumeCapability) *csi.NodeStageVolumeResponse {
 		// NodeStageVolume
 		if nodeStageSupported {
 			By("node staging volume")
 			nodeStageRequest := &csi.NodeStageVolumeRequest{
 				VolumeId:          vol.GetVolume().GetVolumeId(),
-				VolumeCapability:  TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+				VolumeCapability:  volCap,
 				StagingTargetPath: sc.StagingPath,
 				VolumeContext:     vol.GetVolume().GetVolumeContext(),
 				Secrets:           sc.Secrets.NodeStageVolumeSecret,
@@ -230,7 +228,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 		return nil
 	}
 
-	nodePublishVolume := func(volumeName string, vol *csi.CreateVolumeResponse, conpubvol *csi.ControllerPublishVolumeResponse) *csi.NodePublishVolumeResponse {
+	nodePublishVolumeWithCapability := func(volumeName string, vol *csi.CreateVolumeResponse, conpubvol *csi.ControllerPublishVolumeResponse, volCap *csi.VolumeCapability) *csi.NodePublishVolumeResponse {
 		By("publishing the volume on a node")
 		var stagingPath string
 		if nodeStageSupported {
@@ -240,7 +238,7 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 			VolumeId:          vol.GetVolume().GetVolumeId(),
 			TargetPath:        sc.TargetPath + "/target",
 			StagingTargetPath: stagingPath,
-			VolumeCapability:  TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+			VolumeCapability:  volCap,
 			VolumeContext:     vol.GetVolume().GetVolumeContext(),
 			Secrets:           sc.Secrets.NodePublishVolumeSecret,
 		}
@@ -256,6 +254,25 @@ var _ = DescribeSanity("Node Service", func(sc *TestContext) {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nodepubvol).NotTo(BeNil())
 		return nodepubvol
+	}
+
+	defaultVolumeCapability := TestVolumeCapabilityWithAccessType(sc, csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER)
+
+	createVolume := func(volumeName string) *csi.CreateVolumeResponse {
+		By("creating a single node writer volume for expansion")
+		return createVolumeWithCapability(volumeName, defaultVolumeCapability)
+	}
+
+	controllerPublishVolume := func(volumeName string, vol *csi.CreateVolumeResponse, nid *csi.NodeGetInfoResponse) *csi.ControllerPublishVolumeResponse {
+		return controllerPublishVolumeWithCapability(volumeName, vol, nid, defaultVolumeCapability)
+	}
+
+	nodeStageVolume := func(volumeName string, vol *csi.CreateVolumeResponse, conpubvol *csi.ControllerPublishVolumeResponse) *csi.NodeStageVolumeResponse {
+		return nodeStageVolumeWithCapability(volumeName, vol, conpubvol, defaultVolumeCapability)
+	}
+
+	nodePublishVolume := func(volumeName string, vol *csi.CreateVolumeResponse, conpubvol *csi.ControllerPublishVolumeResponse) *csi.NodePublishVolumeResponse {
+		return nodePublishVolumeWithCapability(volumeName, vol, conpubvol, defaultVolumeCapability)
 	}
 
 	BeforeEach(func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds automated sanity verification to enforce the `SINGLE_NODE_SINGLE_WRITER` volume access mode contract as defined in the CSI specification. 

If a CSI driver advertises the `SINGLE_NODE_MULTI_WRITER` node service capability, it permits mounting a volume at multiple target paths concurrently. However, the CSI specification dictates that volumes published with the `SINGLE_NODE_SINGLE_WRITER` access mode must be prevented from concurrent mounting on the same node. This PR ensures conformance by provisioning a `SINGLE_NODE_SINGLE_WRITER` volume and verifying that secondary publish attempts return `FailedPrecondition`.

**Which issue(s) this PR fixes**:
Replaces #421

**Special notes for your reviewer**:

**Testing:** Verified against `csi-driver-host-path` `v1.14.1` via `make test`. Confirmed the new sanity spec actively hits the driver's checking logic and correctly asserts `FailedPrecondition`.

**Does this PR introduce a user-facing change?**:
```release-note
Adds tests for `SINGLE_NODE_SINGLE_WRITER` volume access mode behavior. Drivers advertising the `SINGLE_NODE_MULTI_WRITER` node service capability must reject concurrent publish attempts for `SINGLE_NODE_SINGLE_WRITER` volumes with `FailedPrecondition`.
```